### PR TITLE
ignore this

### DIFF
--- a/AGENT_INSTRUCTIONS.md
+++ b/AGENT_INSTRUCTIONS.md
@@ -10,3 +10,4 @@ This document contains instructions for autonomous coding agents.
   a. do not pollute or deface upstream repo
   b. be considerate when submitting changes and ensure there are minimal conflicts
   c. ensure that material specific to this fork (like readme differences and identifiers) are not submitted upstream
+7. theme settings that are user-facing, especially selected theme and coloured-logo state, must remain transferable independently of full backups so theme iteration does not require whole-app restore flows

--- a/AGENT_INSTRUCTIONS.md
+++ b/AGENT_INSTRUCTIONS.md
@@ -1,0 +1,12 @@
+This document contains instructions for autonomous coding agents. 
+
+1. Use openjdk@17 when building
+2. adhere to NASA coding standards
+3. ensure that this application consumes minimal overhead
+  a. prioritize stability and performance over feature-richness
+4. ensure that lessons learned and regressions to be avoided are added to this document
+5. preserve divergent material when merging from upstream
+6. 
+  a. do not pollute or deface upstream repo
+  b. be considerate when submitting changes and ensure there are minimal conflicts
+  c. ensure that material specific to this fork (like readme differences and identifiers) are not submitted upstream

--- a/README.md
+++ b/README.md
@@ -1,117 +1,83 @@
 # Bifrost -- LED Controller for the AYN Thor
 
-Bifrost is a custom LED controller for the **AYN Thor** handheld (and might work for other handhelds).  
-It provides a collection of LED animations that can run in the background, including:
+Bifrost is a custom LED controller for the **AYN Thor** handheld (and might work for other handhelds).\
+It provides a collection of LED animations that can run in the
+background, including:
 
 - **Ambilight**
 - **Audio Reactive**
 - **Ambi Aurora** (a mix of Ambilight + Audio Reactive)
 - **Classic animations:** Breath, Rainbow, Pulse, and more
 
-Bifrost aims to bring a vibrant, customizable lighting experience to the  
+Bifrost aims to bring a vibrant, customizable lighting experience to the
 AYN Thor while keeping performance and battery consumption in mind.
 
-> ⚠️ **Important:** For animations to work, **Bifrost must stay alive in the background**.  
-> Closing the app or restricting notification (and screen recording for Ambilight) activity will stop LED updates.
+> ⚠️ **Important:** For animations to work, **Bifrost must stay alive in
+> the background**.\
+> Closing the app or restricting notification (and screen recording for Ambilight) activity will stop LED
+> updates.
 
----
+------------------------------------------------------------------------
 
-# ✨ Features
+## ✨ Features
 
-## Ambilight
+### **Ambilight**
 
-Uses Android's screen recording API to sample the screen's left and right average colors.  
-For performance, Bifrost captures the screen in **2×1 pixels** and reads the RGB values directly from the buffer.
+Uses Android's screen recording API to sample the screen's left and
+right average colors.\
+For performance, Bifrost captures the screen in **2×1 pixels** and reads
+the RGB values directly from the buffer.
 
-### Options
 
+**New options:**
 - **Custom color sampler** to eliminate pillarboxing/letterboxing and favor more vivid colors (useful for older content)
 - **Single color mode** to calculate one shared color for both sticks
 - **Saturation boost slider** for more intense colors
 - **Hex color input** for precise color selection
 
-When choosing the custom color sampler, Bifrost captures the screen using a **low-resolution 32-pixel grid**, allowing more advanced color analysis while remaining lightweight:
-
+When choosing the custom colors sampler, Bifrost captures the screen using a
+**low-resolution 32-pixel**, which allows more advanced color
+analysis while remaining lightweight, it:
 - **Favors saturated colors** to improve vibrancy
 - Helps eliminate pillarboxing and letterboxing
 
----
+### **Audio Reactive**
 
-## Audio Reactive
+Analyzes live audio levels (using the screen recording permission) to
+drive LED intensity.
 
-Analyzes live audio levels (using the screen recording permission) to drive LED intensity.
-
-### Improvements
-
-- Redesigned **reactivity system** using a single unified reactivity slider
+**Improvements:**
+- Redesigned **reactivity system** using a single, unified reactivity slider
 - Improved responsiveness and smoother audio-driven animations
 
----
+### **Ambi Aurora**
 
-## Ambi Aurora
+Combines Ambilight color sampling with Audio Reactive intensity for a
+hybrid effect.
 
-Combines Ambilight color sampling with Audio Reactive intensity for a hybrid effect.
-
-### Enhancements
-
+**Enhancements:**
 - Improved color calculation
 - Supports **custom sampling**, **single color mode**, and **saturation boost**
 
----
-
-## Animation Presets
+### **Animation Presets**
 
 - Save multiple animation presets with their own settings
 - Automatically loads the **last selected preset** on app launch
 - Easy organization and quick switching
 
----
+### **Performance Profiles**
 
-## Performance Profiles
+Bifrost offers multiple performance-level modes.\
+The **Ragnarok profile** updates the Thor LED controller **as fast as
+possible**, which may cause latency or even crashes.
 
-Bifrost offers multiple performance-level modes.
+------------------------------------------------------------------------
 
-The **Ragnarok profile** updates the Thor LED controller **as fast as possible**, which may cause latency or even crashes.
-
----
-
-# 🚀 New Features
-
-Recent updates introduce several new capabilities.
-
-## Auto Start
-
-- **Auto-start on boot** so Bifrost resumes automatically after device reboot.
-
-## App-based Profiles
-
-- Profiles can be **assigned to specific apps**
-- Bifrost automatically switches profiles depending on the **foreground application**
-
-## Independent LED Control
-
-- **Separate left/right LED control**
-- Each stick can run **different colors or animations**
-
-## Charging Indicator
-
-Improved LED feedback while charging:
-
-- Breathing lights while charging
-- Charging speed indication
-- Flash notification when charging completes
-
-## CPU Temperature Animation
-
-A new animation that changes LED colors based on **CPU temperature readings**.
-
----
-
-# 📦 Installation
+## 📦 Installation
 
 Bifrost can be installed in two different ways:
 
-## Method 1 — Manual APK install
+### **Method 1 — Manual APK install**
 
 1. Download the latest **APK** from the GitHub releases page.
 2. Open your **Downloads** folder.
@@ -119,90 +85,93 @@ Bifrost can be installed in two different ways:
 4. If Android asks to allow installation from **unknown sources**, accept the permission.
 5. Complete the installation.
 
----
-
-## Method 2 — Install & update via Obtainium (recommended)
+### **Method 2 — Install & update via Obtainium (recommended)**
 
 If you use **Obtainium**, you can automatically receive updates:
 
-1. Open the Obtainium app  
-   https://github.com/ImranR98/Obtainium
+1. Open the Obtainium app. It can be found here : https://github.com/ImranR98/Obtainium
+2. Add a new app using this fork as a source: https://github.com/KuriGohan-Kamehameha/Bifrost/releases/
+   (Optionally, Add using the original source: https://github.com/Pollux-MoonBench/Bifrost/releases/)
+3. Follow the Obtainium installation process
+------------------------------------------------------------------------
 
-2. Add a new app using this source:
-   https://github.com/Pollux-MoonBench/Bifrost/releases/
+## 🔒 Required Permissions
 
-3. Follow the Obtainium installation process.
+To enable Ambilight, Audio Reactive, and Ambi Aurora modes, Bifrost
+requires:
 
----
+- **Screen recording permission**\
+  Used exclusively to sample colors (Ambilight) and volume intensity
+  (Audio Reactive).
 
-# 🔒 Required Permissions
+Bifrost does *not* save or transmit screen contents — sampling happens
+locally and is reduced to minimal pixel data for efficiency.
 
-To enable Ambilight, Audio Reactive, and Ambi Aurora modes, Bifrost requires:
+------------------------------------------------------------------------
 
-### Screen recording permission
-
-Used exclusively to sample:
-
-- Screen colors (Ambilight)
-- Audio intensity (Audio Reactive)
-
-Bifrost does **not save or transmit screen contents** — sampling happens locally and is reduced to minimal pixel data for efficiency.
-
----
-
-# 🎮 Other Tested Devices
+## 🎮 Other Tested Devices
 
 Bifrost has been tested and confirmed to work on the following devices:
 
-### AYN
+AYN
 - Thor
 - Odin 2 Portal Pro
 
-### Retroid
+Retroid
 - Pocket Mini V2
 - Pocket 5
 
----
+------------------------------------------------------------------------
 
-# ⚠️ In Dev Status
+## ⚠️ In Dev Status
 
 Bifrost is now **out of beta**, but still actively evolving.  
-While overall stability has improved, unexpected behavior may still occur on some devices.
+While overall stability has improved, unexpected behavior may still
+occur on some devices.
 
-### Known issues
+Also, this fork is maintained by someone who doesn't understand half 
+the changes they make so keep your expectations low and maybe you'll be pleasantly surprised.
+
+Also also, the maintainer of this fork only cares about their own AYN Thor
+so if you're not using that specific device or something similar you're probably better off using the original version.
+
+### **Known issues**
 
 - Random crashes under certain conditions
-- Granting notification permission at launch may cause the LED toggle switch to appear disabled even though animations continue running
-- On the Retroid Pocket Mini, only the left stick turns on in Ambilight mode.  
-  This issue can be solved using the **custom color sampler mode**.
+- Granting notification permission at launch may cause the LED toggle
+  switch to appear disabled even though animations continue running
+- On the Retroid Pocket Mini, only the left stick turns on in Ambilight mode.
+  This issue can be solved using the custom color sampler mode.
+  (Thanks to r/hupo224 for helping with this issue.)
 
-Thanks to **r/hupo224** for helping investigate this issue.
+If you encounter issues, please open a GitHub issue or check the existing ones.
 
----
+## 🧬 Fork vs Upstream (what’s different?)
 
-# ❤️ Contributors
+This fork contains enhancements that aren’t (yet) in the upstream Pollux-MoonBench/Bifrost main branch.
 
-Huge thanks to **KuriGohan-Kamehameha** for the **massive work and new features added to the project**, including major functionality improvements and system integrations.
+### Key additions
 
-Project:  
-https://github.com/KuriGohan-Kamehameha
+- **Auto-start on boot** to keep Bifrost running after device reboot.
+- Individual left/right control -- make each side a distinct colour!
+- Profiles can now be assigned to apps, and will automatically activate when the selected app is in the foreground. 
+- **Improved charging indicator**:
+  - Breathing lights while charging
+  - Charging speed indication
+  - Flash notification when charging completes
+- **New CPU temperature LED animation** (colors shift based on thermal readings).
 
----
+### Project-level differences
 
-# ☕ Support the Project
+- Includes a **`CHANGELOG.md`** to track releases and notable changes.
+- Releases include a published **APK asset** (tagged `v1.0.6`).
+- Updated UI layout and animation smoothing tweaks across several animations.
 
-If you enjoy Bifrost and want to support development, you can **buy me a coffee** here:
-
-👉 https://ko-fi.com/pollux_moonbench
-
-Thank you! ❤️
-
----
-
-# 📜 License
+## 📜 License
 
 This project is licensed under **GPLv3**.
 
-You are free to use, study, modify, and redistribute the app under the terms of the GPLv3 license.
-
-This app is provided for free in this repository and **cannot be sold to you.**
+You are free to use, study, modify, and redistribute the app under the
+terms of the GPLv3 license.\
+This app is provided for free in this repository and **cannot be sold to
+you.** You should never have to pay for Bifrost!

--- a/app/src/main/java/com/moonbench/bifrost/BackupArchiveTransfer.kt
+++ b/app/src/main/java/com/moonbench/bifrost/BackupArchiveTransfer.kt
@@ -1,0 +1,436 @@
+package com.moonbench.bifrost
+
+import android.content.Context
+import android.content.SharedPreferences
+import android.net.Uri
+import android.os.CancellationSignal
+import org.json.JSONArray
+import org.json.JSONObject
+import java.io.ByteArrayOutputStream
+import java.util.zip.ZipEntry
+import java.util.zip.ZipInputStream
+import java.util.zip.ZipOutputStream
+
+object BackupArchiveTransfer {
+
+    private const val BACKUP_SCHEMA = "bifrost_full_backup"
+    private const val BACKUP_VERSION = 1
+    private const val PREF_FILE_NAME = "bifrost_prefs"
+    private const val MANIFEST_ENTRY_NAME = "manifest.json"
+    private const val PREFS_ENTRY_NAME = "prefs.json"
+    private const val ICONS_DIR_PREFIX = "icons/"
+    private val THEME_PREF_KEYS = setOf(
+        "selected_ui_theme",
+        "colored_logo_enabled"
+    )
+    private val PROFILE_PREF_KEYS = setOf(
+        "presets_json",
+        "last_preset_name",
+        "app_profile_mappings",
+        "auto_switch_enabled",
+        "pending_projection_package",
+        "pending_projection_preset",
+        "pending_projection_notified"
+    )
+
+    data class CategoryOptions(
+        val themes: Boolean = true,
+        val profiles: Boolean = true,
+        val images: Boolean = true
+    ) {
+        fun hasAtLeastOneCategory(): Boolean = themes || profiles || images
+    }
+
+    data class ExportResult(
+        val preferenceCount: Int,
+        val iconCount: Int,
+        val appliedOptions: CategoryOptions,
+        val warnings: List<String>
+    )
+
+    data class ImportResult(
+        val preferenceCount: Int,
+        val iconCount: Int,
+        val appliedOptions: CategoryOptions,
+        val warnings: List<String>,
+        val errors: List<String>
+    )
+
+    fun exportToUri(
+        context: Context,
+        uri: Uri,
+        options: CategoryOptions = CategoryOptions(),
+        cancelSignal: CancellationSignal? = null
+    ): ExportResult {
+        if (!options.hasAtLeastOneCategory()) {
+            return ExportResult(
+                preferenceCount = 0,
+                iconCount = 0,
+                appliedOptions = options,
+                warnings = listOf("No categories were selected for backup.")
+            )
+        }
+
+        val prefs = context.getSharedPreferences(PREF_FILE_NAME, Context.MODE_PRIVATE)
+        val warnings = mutableListOf<String>()
+        val prefsJson = serializePreferences(prefs, options)
+        val iconNames = if (options.images) {
+            PresetImageStorage.listStoredIconFileNames(context)
+        } else {
+            emptyList()
+        }
+        var exportedIconCount = 0
+
+        val manifest = JSONObject().apply {
+            put("schema", BACKUP_SCHEMA)
+            put("version", BACKUP_VERSION)
+            put("prefsFile", PREF_FILE_NAME)
+            put("iconDirectory", "preset_icons")
+            put("categories", JSONObject().apply {
+                put("themes", options.themes)
+                put("profiles", options.profiles)
+                put("images", options.images)
+            })
+        }
+
+        cancelSignal?.throwIfCanceled()
+        context.contentResolver.openOutputStream(uri)?.use { stream ->
+            ZipOutputStream(stream.buffered()).use { zip ->
+                cancelSignal?.throwIfCanceled()
+                zip.putNextEntry(ZipEntry(MANIFEST_ENTRY_NAME))
+                zip.write(manifest.toString(2).toByteArray(Charsets.UTF_8))
+                zip.closeEntry()
+
+                cancelSignal?.throwIfCanceled()
+                zip.putNextEntry(ZipEntry(PREFS_ENTRY_NAME))
+                zip.write(prefsJson.toString(2).toByteArray(Charsets.UTF_8))
+                zip.closeEntry()
+
+                iconNames.forEach { iconName ->
+                    cancelSignal?.throwIfCanceled()
+                    val input = PresetImageStorage.openIconInputStream(context, iconName)
+                    if (input == null) {
+                        warnings += "Image not found for '$iconName'; skipping."
+                        return@forEach
+                    }
+
+                    input.use { iconStream ->
+                        cancelSignal?.throwIfCanceled()
+                        zip.putNextEntry(ZipEntry("$ICONS_DIR_PREFIX$iconName"))
+                        iconStream.copyTo(zip)
+                        zip.closeEntry()
+                        exportedIconCount++
+                    }
+                }
+            }
+        } ?: return ExportResult(
+            preferenceCount = 0,
+            iconCount = 0,
+            appliedOptions = options,
+            warnings = listOf("Unable to write selected file.")
+        )
+
+        return ExportResult(
+            preferenceCount = prefs.all.size,
+            iconCount = exportedIconCount,
+            appliedOptions = options,
+            warnings = warnings
+        )
+    }
+
+    fun importFromUri(
+        context: Context,
+        uri: Uri,
+        options: CategoryOptions = CategoryOptions(),
+        cancelSignal: CancellationSignal? = null
+    ): ImportResult {
+        if (!options.hasAtLeastOneCategory()) {
+            return ImportResult(
+                preferenceCount = 0,
+                iconCount = 0,
+                appliedOptions = options,
+                warnings = emptyList(),
+                errors = listOf("No categories were selected for restore.")
+            )
+        }
+
+        val warnings = mutableListOf<String>()
+        val errors = mutableListOf<String>()
+
+        val zipEntries = mutableMapOf<String, ByteArray>()
+        cancelSignal?.throwIfCanceled()
+        context.contentResolver.openInputStream(uri)?.use { input ->
+            ZipInputStream(input.buffered()).use { zip ->
+                while (true) {
+                    cancelSignal?.throwIfCanceled()
+                    val entry = zip.nextEntry ?: break
+                    if (entry.isDirectory) {
+                        zip.closeEntry()
+                        continue
+                    }
+
+                    val data = ByteArrayOutputStream().use { output ->
+                        zip.copyTo(output)
+                        output.toByteArray()
+                    }
+                    zipEntries[entry.name] = data
+                    zip.closeEntry()
+                }
+            }
+        } ?: return ImportResult(
+            preferenceCount = 0,
+            iconCount = 0,
+            appliedOptions = options,
+            warnings = emptyList(),
+            errors = listOf("Unable to read selected file.")
+        )
+
+        val manifestRaw = zipEntries[MANIFEST_ENTRY_NAME]
+            ?: return ImportResult(
+                preferenceCount = 0,
+                iconCount = 0,
+                appliedOptions = options,
+                warnings = emptyList(),
+                errors = listOf("Archive is missing manifest.json")
+            )
+
+        val manifest = runCatching {
+            JSONObject(manifestRaw.toString(Charsets.UTF_8))
+        }.getOrElse {
+            return ImportResult(
+                preferenceCount = 0,
+                iconCount = 0,
+                appliedOptions = options,
+                warnings = emptyList(),
+                errors = listOf("manifest.json is invalid JSON")
+            )
+        }
+
+        if (manifest.optString("schema") != BACKUP_SCHEMA) {
+            errors += "Unknown backup schema."
+            return ImportResult(
+                preferenceCount = 0,
+                iconCount = 0,
+                appliedOptions = options,
+                warnings = warnings,
+                errors = errors
+            )
+        }
+
+        val version = manifest.optInt("version", -1)
+        if (version < 1) {
+            errors += "Unsupported backup version: $version"
+            return ImportResult(
+                preferenceCount = 0,
+                iconCount = 0,
+                appliedOptions = options,
+                warnings = warnings,
+                errors = errors
+            )
+        } else if (version > BACKUP_VERSION) {
+            warnings += "Backup version $version is newer than supported version $BACKUP_VERSION. Attempting compatible restore."
+        }
+
+        val prefsRaw = zipEntries[PREFS_ENTRY_NAME]
+            ?: return ImportResult(
+                preferenceCount = 0,
+                iconCount = 0,
+                appliedOptions = options,
+                warnings = warnings,
+                errors = listOf("Archive is missing prefs.json")
+            )
+
+        val prefsJson = runCatching {
+            JSONObject(prefsRaw.toString(Charsets.UTF_8))
+        }.getOrElse {
+            return ImportResult(
+                preferenceCount = 0,
+                iconCount = 0,
+                appliedOptions = options,
+                warnings = warnings,
+                errors = listOf("prefs.json is invalid JSON")
+            )
+        }
+
+        val effectiveOptions = resolveEffectiveOptions(manifest, options)
+
+        val prefItems = prefsJson.optJSONArray("items") ?: JSONArray()
+        val prefs = context.getSharedPreferences(PREF_FILE_NAME, Context.MODE_PRIVATE)
+        val editor = prefs.edit()
+
+        if (effectiveOptions.themes) {
+            THEME_PREF_KEYS.forEach { editor.remove(it) }
+        }
+        if (effectiveOptions.profiles) {
+            PROFILE_PREF_KEYS.forEach { editor.remove(it) }
+        }
+
+        var importedPrefCount = 0
+        for (index in 0 until prefItems.length()) {
+            cancelSignal?.throwIfCanceled()
+            val item = prefItems.optJSONObject(index) ?: continue
+            val key = item.optString("key").takeIf { it.isNotBlank() } ?: continue
+            if (!shouldIncludePreference(key, effectiveOptions)) continue
+            val type = item.optString("type")
+
+            when (type) {
+                "boolean" -> {
+                    editor.putBoolean(key, item.optBoolean("value", false))
+                    importedPrefCount++
+                }
+
+                "int" -> {
+                    editor.putInt(key, item.optInt("value", 0))
+                    importedPrefCount++
+                }
+
+                "long" -> {
+                    val value = item.optLong("value", 0L)
+                    editor.putLong(key, value)
+                    importedPrefCount++
+                }
+
+                "float" -> {
+                    val value = item.optDouble("value", 0.0).toFloat()
+                    editor.putFloat(key, value)
+                    importedPrefCount++
+                }
+
+                "string" -> {
+                    editor.putString(key, item.optString("value"))
+                    importedPrefCount++
+                }
+
+                "string_set" -> {
+                    val valueArray = item.optJSONArray("value") ?: JSONArray()
+                    val valueSet = linkedSetOf<String>()
+                    for (setIndex in 0 until valueArray.length()) {
+                        val value = valueArray.optString(setIndex)
+                        if (value.isNotEmpty()) valueSet += value
+                    }
+                    editor.putStringSet(key, valueSet)
+                    importedPrefCount++
+                }
+
+                else -> warnings += "Preference '$key' uses unsupported type '$type'; skipping."
+            }
+        }
+
+        if (!editor.commit()) {
+            return ImportResult(
+                preferenceCount = 0,
+                iconCount = 0,
+                appliedOptions = effectiveOptions,
+                warnings = warnings,
+                errors = listOf("Failed to commit restored preferences")
+            )
+        }
+
+        var importedIconCount = 0
+        if (effectiveOptions.images) {
+            PresetImageStorage.clearAllIcons(context)
+            zipEntries.forEach { (entryName, bytes) ->
+                cancelSignal?.throwIfCanceled()
+                if (!entryName.startsWith(ICONS_DIR_PREFIX)) return@forEach
+
+                val fileName = entryName.removePrefix(ICONS_DIR_PREFIX).trim()
+                if (fileName.isBlank()) return@forEach
+
+                if (PresetImageStorage.writeIconWithExactName(context, fileName, bytes)) {
+                    importedIconCount++
+                } else {
+                    warnings += "Could not restore image '$fileName'."
+                }
+            }
+        }
+
+        if (effectiveOptions.profiles && !effectiveOptions.images) {
+            warnings += "Profiles restored without images; presets that reference uploaded images may show missing artwork."
+        }
+
+        return ImportResult(
+            preferenceCount = importedPrefCount,
+            iconCount = importedIconCount,
+            appliedOptions = effectiveOptions,
+            warnings = warnings,
+            errors = errors
+        )
+    }
+
+    private fun serializePreferences(prefs: SharedPreferences, options: CategoryOptions): JSONObject {
+        val items = JSONArray()
+
+        prefs.all.toSortedMap().forEach { (key, value) ->
+            if (!shouldIncludePreference(key, options)) {
+                return@forEach
+            }
+
+            val item = JSONObject().apply { put("key", key) }
+            when (value) {
+                is Boolean -> {
+                    item.put("type", "boolean")
+                    item.put("value", value)
+                }
+
+                is Int -> {
+                    item.put("type", "int")
+                    item.put("value", value)
+                }
+
+                is Long -> {
+                    item.put("type", "long")
+                    item.put("value", value)
+                }
+
+                is Float -> {
+                    item.put("type", "float")
+                    item.put("value", value.toDouble())
+                }
+
+                is String -> {
+                    item.put("type", "string")
+                    item.put("value", value)
+                }
+
+                is Set<*> -> {
+                    val setValues = value
+                        .filterIsInstance<String>()
+                        .sorted()
+                    item.put("type", "string_set")
+                    item.put("value", JSONArray(setValues))
+                }
+
+                else -> {
+                    // Ignore unsupported preference types
+                    return@forEach
+                }
+            }
+            items.put(item)
+        }
+
+        return JSONObject().apply {
+            put("items", items)
+        }
+    }
+
+    private fun shouldIncludePreference(key: String, options: CategoryOptions): Boolean {
+        return (options.themes && key in THEME_PREF_KEYS) ||
+            (options.profiles && key in PROFILE_PREF_KEYS)
+    }
+
+    private fun resolveEffectiveOptions(
+        manifest: JSONObject,
+        requested: CategoryOptions
+    ): CategoryOptions {
+        val categories = manifest.optJSONObject("categories")
+        if (categories == null) {
+            return requested
+        }
+
+        return CategoryOptions(
+            themes = requested.themes && categories.optBoolean("themes", true),
+            profiles = requested.profiles && categories.optBoolean("profiles", true),
+            images = requested.images && categories.optBoolean("images", true)
+        )
+    }
+}

--- a/app/src/main/java/com/moonbench/bifrost/MainActivity.kt
+++ b/app/src/main/java/com/moonbench/bifrost/MainActivity.kt
@@ -85,11 +85,14 @@ class MainActivity : AppCompatActivity() {
     private lateinit var autoStartupSwitch: SwitchMaterial
     private lateinit var pluggedBatteryOverrideSwitch: SwitchMaterial
     private lateinit var persistentNotificationSwitch: SwitchMaterial
+    private lateinit var adaptiveBrightnessSwitch: SwitchMaterial
     private lateinit var mediaProjectionManager: MediaProjectionManager
     private lateinit var animationSpinner: Spinner
     private lateinit var profileSpinner: Spinner
     private lateinit var presetSpinner: Spinner
     private lateinit var themeSpinner: Spinner
+    private lateinit var exportThemeButton: MaterialButton
+    private lateinit var importThemeButton: MaterialButton
     private lateinit var savePresetButton: MaterialButton
     private lateinit var modifyPresetButton: MaterialButton
     private lateinit var deletePresetButton: MaterialButton
@@ -209,6 +212,7 @@ class MainActivity : AppCompatActivity() {
         private const val PREF_THOR_AMBILIGHT_BOTTOM_SCREEN = "thor_ambilight_bottom_screen"
         private const val PREF_BATTERY_OVERRIDE_WHEN_PLUGGED = "battery_override_when_plugged"
         private const val PREF_PERSISTENT_NOTIFICATION = "persistent_notification_enabled"
+        private const val PREF_ADAPTIVE_BRIGHTNESS = "adaptive_brightness_enabled"
         private const val PREF_SELECTED_UI_THEME = "selected_ui_theme"
         private const val PREF_COLORED_LOGO_ENABLED = "colored_logo_enabled"
         private const val EXTRA_DISPLAY_RELAUNCH_ATTEMPT = "display_relaunch_attempt"
@@ -253,6 +257,7 @@ class MainActivity : AppCompatActivity() {
     private var selectedFlashWhenReady: Boolean = false
     private var selectedBatteryOverrideWhenPlugged: Boolean = false
     private var selectedPersistentNotification: Boolean = true
+    private var selectedAdaptiveBrightness: Boolean = false
     private var isAwaitingPermissionResult = false
     private var isUpdatingFromPreset = false
     private var isGrantingProjectionForAppProfile = false
@@ -276,6 +281,8 @@ class MainActivity : AppCompatActivity() {
     private var presetArtworkSheetDialog: BottomSheetDialog? = null
     private var appProfileSyncRunnable: Runnable? = null
     private var resumeStateSyncRunnable: Runnable? = null
+    private var pendingBackupExportOptions: BackupArchiveTransfer.CategoryOptions? = null
+    private var pendingBackupImportOptions: BackupArchiveTransfer.CategoryOptions? = null
 
     private val mainHandler = Handler(Looper.getMainLooper())
     private lateinit var presetController: PresetController
@@ -448,13 +455,29 @@ class MainActivity : AppCompatActivity() {
     private val exportPresetsLauncher =
         registerForActivityResult(ActivityResultContracts.CreateDocument("application/octet-stream")) { uri: Uri? ->
             if (uri == null) return@registerForActivityResult
-            exportPresetBundle(uri)
+            val options = pendingBackupExportOptions ?: BackupArchiveTransfer.CategoryOptions()
+            pendingBackupExportOptions = null
+            exportPresetBundle(uri, options)
+        }
+
+    private val exportThemeLauncher =
+        registerForActivityResult(ActivityResultContracts.CreateDocument("application/json")) { uri: Uri? ->
+            if (uri == null) return@registerForActivityResult
+            exportThemeBundle(uri)
         }
 
     private val importPresetsLauncher =
         registerForActivityResult(ActivityResultContracts.OpenDocument()) { uri: Uri? ->
             if (uri == null) return@registerForActivityResult
-            importPresetBundle(uri)
+            val options = pendingBackupImportOptions ?: BackupArchiveTransfer.CategoryOptions()
+            pendingBackupImportOptions = null
+            importPresetBundle(uri, options)
+        }
+
+    private val importThemeLauncher =
+        registerForActivityResult(ActivityResultContracts.OpenDocument()) { uri: Uri? ->
+            if (uri == null) return@registerForActivityResult
+            importThemeBundle(uri)
         }
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -524,10 +547,13 @@ class MainActivity : AppCompatActivity() {
         autoStartupSwitch = findViewById(R.id.autoStartupSwitch)
         pluggedBatteryOverrideSwitch = findViewById(R.id.pluggedBatteryOverrideSwitch)
         persistentNotificationSwitch = findViewById(R.id.persistentNotificationSwitch)
+        adaptiveBrightnessSwitch = findViewById(R.id.adaptiveBrightnessSwitch)
         animationSpinner = findViewById(R.id.animationSpinner)
         profileSpinner = findViewById(R.id.profileSpinner)
         presetSpinner = findViewById(R.id.presetSpinner)
         themeSpinner = findViewById(R.id.themeSpinner)
+        exportThemeButton = findViewById(R.id.exportThemeButton)
+        importThemeButton = findViewById(R.id.importThemeButton)
         savePresetButton = findViewById(R.id.savePresetButton)
         modifyPresetButton = findViewById(R.id.modifyPresetButton)
         deletePresetButton = findViewById(R.id.deletePresetButton)
@@ -607,6 +633,7 @@ class MainActivity : AppCompatActivity() {
         setupAutoStartupSwitch()
         setupPluggedBatteryOverrideSwitch()
         setupPersistentNotificationSwitch()
+        setupAdaptiveBrightnessSwitch()
         setupThorScreenPreference()
         setupSettingsTabs()
         setupThemeFeature()
@@ -2578,6 +2605,20 @@ class MainActivity : AppCompatActivity() {
         }
     }
 
+    private fun setupAdaptiveBrightnessSwitch() {
+        selectedAdaptiveBrightness = prefs.getBoolean(PREF_ADAPTIVE_BRIGHTNESS, false)
+        adaptiveBrightnessSwitch.isChecked = selectedAdaptiveBrightness
+
+        adaptiveBrightnessSwitch.setOnCheckedChangeListener { _, isChecked ->
+            selectedAdaptiveBrightness = isChecked
+            prefs.edit().putBoolean(PREF_ADAPTIVE_BRIGHTNESS, isChecked).apply()
+
+            if (LEDService.isRunning && !serviceController.isServiceTransitioning) {
+                sendLiveUpdateToLedService()
+            }
+        }
+    }
+
     private fun setupThorScreenPreference() {
         val thorCard = findViewById<View>(R.id.thorSettingsCard) ?: return
         if (!DeviceInfo.isAynThor) {
@@ -2942,12 +2983,35 @@ class MainActivity : AppCompatActivity() {
         syncAppProfileDefaultSwitch()
 
         exportPresetsButton.setOnClickListener {
-            val timestamp = SimpleDateFormat("yyyyMMdd_HHmmss", Locale.US).format(Date())
-            exportPresetsLauncher.launch("bifrost_presets_$timestamp.bifrost_preset")
+            showBackupCategoryDialog(
+                title = "BACKUP CATEGORIES",
+                subtitle = "Choose what to include in the backup",
+                confirmLabel = "BACKUP"
+            ) { options ->
+                pendingBackupExportOptions = options
+                val timestamp = SimpleDateFormat("yyyyMMdd_HHmmss", Locale.US).format(Date())
+                exportPresetsLauncher.launch("bifrost_backup_$timestamp.bifrost_backup")
+            }
         }
 
         importPresetsButton.setOnClickListener {
-            importPresetsLauncher.launch(arrayOf("*/*"))
+            showBackupCategoryDialog(
+                title = "RESTORE CATEGORIES",
+                subtitle = "Choose what to restore from archive",
+                confirmLabel = "RESTORE"
+            ) { options ->
+                pendingBackupImportOptions = options
+                importPresetsLauncher.launch(arrayOf("*/*"))
+            }
+        }
+
+        exportThemeButton.setOnClickListener {
+            val timestamp = SimpleDateFormat("yyyyMMdd_HHmmss", Locale.US).format(Date())
+            exportThemeLauncher.launch("bifrost_theme_$timestamp.bifrost_theme")
+        }
+
+        importThemeButton.setOnClickListener {
+            importThemeLauncher.launch(arrayOf("*/*"))
         }
 
         // If the app switching feature is already enabled, start syncing the UI after presets load.
@@ -2956,23 +3020,18 @@ class MainActivity : AppCompatActivity() {
         }
     }
 
-    private fun exportPresetBundle(uri: Uri) {
+    private fun exportPresetBundle(uri: Uri, options: BackupArchiveTransfer.CategoryOptions) {
         val result = runCatching {
-            PresetArchiveTransfer.exportToUri(
-                context = this,
-                uri = uri,
-                presets = presetController.getPresets(),
-                mappings = appProfileManager.getMappings()
-            )
+            BackupArchiveTransfer.exportToUri(context = this, uri = uri, options = options)
         }.getOrElse {
-            Toast.makeText(this, "Preset export failed", Toast.LENGTH_LONG).show()
+            Toast.makeText(this, "Backup export failed", Toast.LENGTH_LONG).show()
             return
         }
 
         if (result.warnings.isEmpty()) {
             Toast.makeText(
                 this,
-                "Exported ${result.presetCount} presets (${result.iconCount} icons)",
+                "Backup saved (${result.preferenceCount} settings, ${result.iconCount} images)",
                 Toast.LENGTH_LONG
             ).show()
             return
@@ -2981,8 +3040,8 @@ class MainActivity : AppCompatActivity() {
         val warningText = result.warnings.joinToString("\n")
         BifrostAlertDialog().show(
             activity = this,
-            title = "EXPORT COMPLETED",
-            subtitle = "Exported ${result.presetCount} presets with ${result.warnings.size} warning(s)",
+            title = "BACKUP COMPLETED",
+            subtitle = "Saved backup with ${result.warnings.size} warning(s)",
             body = warningText,
             positiveLabelResId = R.string.alert_action_ok,
             negativeLabelResId = null,
@@ -2991,15 +3050,64 @@ class MainActivity : AppCompatActivity() {
         )
     }
 
-    private fun importPresetBundle(uri: Uri) {
-        val result = runCatching {
-            PresetArchiveTransfer.importFromUri(this, uri)
+    private fun importPresetBundle(uri: Uri, options: BackupArchiveTransfer.CategoryOptions) {
+        val backupResult = runCatching {
+            BackupArchiveTransfer.importFromUri(this, uri, options = options)
         }.getOrElse {
             BifrostAlertDialog().show(
                 activity = this,
                 title = "IMPORT FAILED",
                 subtitle = "Selected file could not be imported",
                 body = it.message,
+                positiveLabelResId = R.string.alert_action_ok,
+                negativeLabelResId = null,
+                cancelable = true,
+                onConfirm = {}
+            )
+            return
+        }
+
+        if (backupResult.errors.isEmpty()) {
+            val categorySummary = describeBackupCategories(backupResult.appliedOptions)
+            val warningText = if (backupResult.warnings.isEmpty()) {
+                "Categories: $categorySummary\n\nRestore completed successfully."
+            } else {
+                "Categories: $categorySummary\n\nWarnings:\n${backupResult.warnings.joinToString("\n")}"
+            }
+
+            BifrostAlertDialog().show(
+                activity = this,
+                title = "RESTORE COMPLETED",
+                subtitle = "Restored ${backupResult.preferenceCount} settings and ${backupResult.iconCount} images",
+                body = warningText,
+                positiveLabelResId = R.string.alert_action_ok,
+                negativeLabelResId = null,
+                cancelable = true,
+                onConfirm = {
+                    recreate()
+                }
+            )
+            return
+        }
+
+        // Fallback: allow importing legacy preset bundles through the same picker.
+        val result = runCatching {
+            PresetArchiveTransfer.importFromUri(this, uri)
+        }.getOrElse {
+            val mergedErrorText = buildString {
+                append(backupResult.errors.joinToString("\n"))
+                if (isNotEmpty()) append("\n\n")
+                append("Legacy preset import failed")
+                it.message?.let { message ->
+                    append(": ")
+                    append(message)
+                }
+            }
+            BifrostAlertDialog().show(
+                activity = this,
+                title = "IMPORT FAILED",
+                subtitle = "Selected file is not a valid backup archive",
+                body = mergedErrorText,
                 positiveLabelResId = R.string.alert_action_ok,
                 negativeLabelResId = null,
                 cancelable = true,
@@ -3028,6 +3136,45 @@ class MainActivity : AppCompatActivity() {
                 applyImportedBundle(result, replaceEverything = false)
             }
         )
+    }
+
+    private fun showBackupCategoryDialog(
+        title: String,
+        subtitle: String,
+        confirmLabel: String,
+        onConfirm: (BackupArchiveTransfer.CategoryOptions) -> Unit
+    ) {
+        val labels = arrayOf("Themes", "Profiles", "Images")
+        val checked = booleanArrayOf(true, true, true)
+
+        AlertDialog.Builder(this)
+            .setTitle(title)
+            .setMessage(subtitle)
+            .setMultiChoiceItems(labels, checked) { _, which, isChecked ->
+                checked[which] = isChecked
+            }
+            .setPositiveButton(confirmLabel) { _, _ ->
+                val options = BackupArchiveTransfer.CategoryOptions(
+                    themes = checked[0],
+                    profiles = checked[1],
+                    images = checked[2]
+                )
+                if (!options.hasAtLeastOneCategory()) {
+                    Toast.makeText(this, "Select at least one category", Toast.LENGTH_SHORT).show()
+                    return@setPositiveButton
+                }
+                onConfirm(options)
+            }
+            .setNegativeButton(R.string.action_cancel, null)
+            .show()
+    }
+
+    private fun describeBackupCategories(options: BackupArchiveTransfer.CategoryOptions): String {
+        val selected = mutableListOf<String>()
+        if (options.themes) selected += "Themes"
+        if (options.profiles) selected += "Profiles"
+        if (options.images) selected += "Images"
+        return if (selected.isEmpty()) "None" else selected.joinToString(" + ")
     }
 
     private fun applyImportedBundle(
@@ -3063,6 +3210,118 @@ class MainActivity : AppCompatActivity() {
         }
 
         showImportReport(result)
+    }
+
+    private fun exportThemeBundle(uri: Uri) {
+        val result = runCatching {
+            ThemeArchiveTransfer.exportToUri(
+                context = this,
+                uri = uri,
+                themeId = selectedUiTheme.id,
+                coloredLogoEnabled = isColoredLogoEnabled
+            )
+        }.getOrElse {
+            Toast.makeText(this, "Theme export failed", Toast.LENGTH_LONG).show()
+            return
+        }
+
+        if (result.warnings.isEmpty()) {
+            Toast.makeText(
+                this,
+                "Theme saved (${selectedUiTheme.label})",
+                Toast.LENGTH_LONG
+            ).show()
+            return
+        }
+
+        BifrostAlertDialog().show(
+            activity = this,
+            title = "THEME EXPORT COMPLETED",
+            subtitle = "Saved ${selectedUiTheme.label} with ${result.warnings.size} warning(s)",
+            body = result.warnings.joinToString("\n"),
+            positiveLabelResId = R.string.alert_action_ok,
+            negativeLabelResId = null,
+            cancelable = true,
+            onConfirm = {}
+        )
+    }
+
+    private fun importThemeBundle(uri: Uri) {
+        val result = runCatching {
+            ThemeArchiveTransfer.importFromUri(this, uri)
+        }.getOrElse {
+            BifrostAlertDialog().show(
+                activity = this,
+                title = "THEME IMPORT FAILED",
+                subtitle = "Selected file could not be imported",
+                body = it.message,
+                positiveLabelResId = R.string.alert_action_ok,
+                negativeLabelResId = null,
+                cancelable = true,
+                onConfirm = {}
+            )
+            return
+        }
+
+        val importedTheme = builtInThemes.firstOrNull { it.id == result.themeId }
+        val errors = result.errors.toMutableList()
+        if (importedTheme == null) {
+            errors += if (result.themeId.isNullOrBlank()) {
+                "Theme bundle does not contain a supported theme."
+            } else {
+                "Theme '${result.themeId}' is not available in this build."
+            }
+        }
+
+        if (errors.isNotEmpty()) {
+            BifrostAlertDialog().show(
+                activity = this,
+                title = "THEME IMPORT FAILED",
+                subtitle = "Selected file is not a valid supported theme bundle",
+                body = (errors + result.warnings).joinToString("\n"),
+                positiveLabelResId = R.string.alert_action_ok,
+                negativeLabelResId = null,
+                cancelable = true,
+                onConfirm = {}
+            )
+            return
+        }
+
+        applyImportedTheme(importedTheme!!, result.coloredLogoEnabled)
+
+        val body = if (result.warnings.isEmpty()) {
+            "Theme applied successfully."
+        } else {
+            "Warnings:\n${result.warnings.joinToString("\n")}"
+        }
+
+        BifrostAlertDialog().show(
+            activity = this,
+            title = "THEME IMPORT COMPLETED",
+            subtitle = "Applied ${importedTheme.label}",
+            body = body,
+            positiveLabelResId = R.string.alert_action_ok,
+            negativeLabelResId = null,
+            cancelable = true,
+            onConfirm = {}
+        )
+    }
+
+    private fun applyImportedTheme(theme: UiTheme, coloredLogoEnabled: Boolean) {
+        prefs.edit()
+            .putString(PREF_SELECTED_UI_THEME, theme.id)
+            .putBoolean(PREF_COLORED_LOGO_ENABLED, coloredLogoEnabled)
+            .apply()
+
+        isColoredLogoEnabled = coloredLogoEnabled
+        val themeIndex = builtInThemes.indexOfFirst { it.id == theme.id }.takeIf { it >= 0 } ?: 0
+        themeSpinner.setSelection(themeIndex, false)
+        applySelectedTheme(theme, persistSelection = false)
+        if (coloredLogoSwitch.isChecked != coloredLogoEnabled) {
+            coloredLogoSwitch.isChecked = coloredLogoEnabled
+        } else {
+            applyHeaderLogoPreference()
+        }
     }
 
     private fun showImportReport(result: PresetArchiveTransfer.ImportResult) {
@@ -3328,6 +3587,10 @@ class MainActivity : AppCompatActivity() {
                 LEDService.EXTRA_PERSISTENT_NOTIFICATION,
                 selectedPersistentNotification
             )
+            putExtra(
+                LEDService.EXTRA_ADAPTIVE_BRIGHTNESS,
+                selectedAdaptiveBrightness
+            )
             putExtra("ambilightDisplayId", getAmbilightTargetDisplayId())
             putExtra(
                 LEDService.EXTRA_ALLOW_BACKGROUND_RUN,
@@ -3378,6 +3641,10 @@ class MainActivity : AppCompatActivity() {
             putExtra(
                 LEDService.EXTRA_PERSISTENT_NOTIFICATION,
                 selectedPersistentNotification
+            )
+            putExtra(
+                LEDService.EXTRA_ADAPTIVE_BRIGHTNESS,
+                selectedAdaptiveBrightness
             )
         }
         startService(intent)

--- a/app/src/main/java/com/moonbench/bifrost/MainActivity.kt
+++ b/app/src/main/java/com/moonbench/bifrost/MainActivity.kt
@@ -2435,10 +2435,6 @@ class MainActivity : AppCompatActivity() {
             object : SeekBar.OnSeekBarChangeListener {
                 override fun onProgressChanged(seekBar: SeekBar?, progress: Int, fromUser: Boolean) {
                     selectedSpeed = progress / 100f
-                    selectedSmoothness = selectedSpeed
-                    if (fromUser) {
-                        smoothnessSeekBar.progress = progress
-                    }
                     if (LEDService.isRunning && fromUser && !serviceController.isServiceTransitioning && !isUpdatingFromPreset) {
                         sendLiveUpdateToLedService()
                     }
@@ -2456,10 +2452,6 @@ class MainActivity : AppCompatActivity() {
             object : SeekBar.OnSeekBarChangeListener {
                 override fun onProgressChanged(seekBar: SeekBar?, progress: Int, fromUser: Boolean) {
                     selectedSmoothness = progress / 100f
-                    selectedSpeed = selectedSmoothness
-                    if (fromUser) {
-                        speedSeekBar.progress = progress
-                    }
                     if (LEDService.isRunning && fromUser && !serviceController.isServiceTransitioning && !isUpdatingFromPreset) {
                         sendLiveUpdateToLedService()
                     }
@@ -3412,11 +3404,11 @@ class MainActivity : AppCompatActivity() {
             val ignoreletterbox = findViewById<View>(R.id.ignoreletterbox)
             var bothSticksSameColor = findViewById<View>(R.id.bothSticksSameColor)
 
-            speedLabel?.visibility = if (needsSpeed || needsSmoothness) View.VISIBLE else View.GONE
-            speedSeekBar.visibility = if (needsSpeed || needsSmoothness) View.VISIBLE else View.GONE
+            speedLabel?.visibility = if (needsSpeed) View.VISIBLE else View.GONE
+            speedSeekBar.visibility = if (needsSpeed) View.VISIBLE else View.GONE
 
-            smoothnessLabel?.visibility = View.GONE
-            smoothnessSeekBar.visibility = View.GONE
+            smoothnessLabel?.visibility = if (needsSmoothness) View.VISIBLE else View.GONE
+            smoothnessSeekBar.visibility = if (needsSmoothness) View.VISIBLE else View.GONE
 
             sensitivityLabel?.visibility = if (needsSensitivity) View.VISIBLE else View.GONE
             sensitivitySeekBar.visibility = if (needsSensitivity) View.VISIBLE else View.GONE

--- a/app/src/main/java/com/moonbench/bifrost/MainActivity.kt
+++ b/app/src/main/java/com/moonbench/bifrost/MainActivity.kt
@@ -5,6 +5,7 @@ import android.animation.AnimatorListenerAdapter
 import android.animation.ValueAnimator
 import android.Manifest
 import android.app.ActivityOptions
+import android.content.res.ColorStateList
 import android.content.Intent
 import android.content.pm.PackageManager
 import android.graphics.Color
@@ -88,6 +89,7 @@ class MainActivity : AppCompatActivity() {
     private lateinit var animationSpinner: Spinner
     private lateinit var profileSpinner: Spinner
     private lateinit var presetSpinner: Spinner
+    private lateinit var themeSpinner: Spinner
     private lateinit var savePresetButton: MaterialButton
     private lateinit var modifyPresetButton: MaterialButton
     private lateinit var deletePresetButton: MaterialButton
@@ -115,12 +117,16 @@ class MainActivity : AppCompatActivity() {
     private lateinit var appProfileSwitch: SwitchMaterial
     private lateinit var homeAppProfileSwitch: SwitchMaterial
     private lateinit var appProfileDefaultSwitch: SwitchMaterial
+    private lateinit var coloredLogoSwitch: SwitchMaterial
     private lateinit var assignAppButton: MaterialButton
     private lateinit var manageAppsButton: MaterialButton
     private lateinit var settingsOverlay: View
     private lateinit var homeContainer: View
     private lateinit var homeSettingsButton: MaterialButton
     private lateinit var closeSettingsButton: MaterialButton
+    private lateinit var tabUiSettings: MaterialButton
+    private lateinit var tabBehaviorSettings: MaterialButton
+    private lateinit var tabThemesSettings: MaterialButton
     private lateinit var presetCoverFlowScroll: LockableHorizontalScrollView
     private lateinit var presetCoverFlowContainer: LinearLayout
     private lateinit var activePresetInfoCard: MaterialCardView
@@ -129,9 +135,12 @@ class MainActivity : AppCompatActivity() {
     private lateinit var activePresetAnimationText: TextView
     private lateinit var activePresetProfileText: TextView
     private lateinit var modeCard: MaterialCardView
+    private lateinit var appProfileCard: MaterialCardView
     private lateinit var colorCard: MaterialCardView
     private lateinit var animationCard: MaterialCardView
     private lateinit var performanceCard: MaterialCardView
+    private lateinit var themesCard: MaterialCardView
+    private lateinit var settingsSystemStatusCard: MaterialCardView
     private lateinit var systemStatusContainer: View
     private lateinit var bifrostLogoView: ImageView
     private lateinit var bifrostTitleText: TextView
@@ -139,6 +148,41 @@ class MainActivity : AppCompatActivity() {
     private var thorAmbilightBottomSwitch: SwitchMaterial? = null
 
     private val prefs by lazy { getSharedPreferences("bifrost_prefs", MODE_PRIVATE) }
+
+    private enum class SettingsTab {
+        UI,
+        BEHAVIOR,
+        THEMES
+    }
+
+    private data class HeaderThemePalette(
+        val introHueStart: Float,
+        val introHueSpan: Float,
+        val introSaturation: Float,
+        val introValue: Float,
+        val settleHueStart: Float,
+        val settleHueSpan: Float,
+        val settleHueWobbleAmplitude: Float,
+        val settleSaturationBase: Float,
+        val settleSaturationWave: Float,
+        val settleValueBase: Float,
+        val settleValueWave: Float,
+        val settleAlphaBase: Int,
+        val settleAlphaWave: Int,
+        val settlePhaseDegrees: Float
+    )
+
+    private data class UiTheme(
+        val id: String,
+        val label: String,
+        val backgroundColor: Int,
+        val cardColor: Int,
+        val surfaceColor: Int,
+        val textColor: Int,
+        val accentColor: Int,
+        val accentLightColor: Int,
+        val headerPalette: HeaderThemePalette
+    )
 
     companion object {
         var mediaProjectionResultCode: Int? = null
@@ -165,6 +209,8 @@ class MainActivity : AppCompatActivity() {
         private const val PREF_THOR_AMBILIGHT_BOTTOM_SCREEN = "thor_ambilight_bottom_screen"
         private const val PREF_BATTERY_OVERRIDE_WHEN_PLUGGED = "battery_override_when_plugged"
         private const val PREF_PERSISTENT_NOTIFICATION = "persistent_notification_enabled"
+        private const val PREF_SELECTED_UI_THEME = "selected_ui_theme"
+        private const val PREF_COLORED_LOGO_ENABLED = "colored_logo_enabled"
         private const val EXTRA_DISPLAY_RELAUNCH_ATTEMPT = "display_relaunch_attempt"
         private const val MAX_DISPLAY_RELAUNCH_ATTEMPTS = 3
         private const val COLOR_OVERRIDE_UNSET = Int.MIN_VALUE
@@ -222,6 +268,8 @@ class MainActivity : AppCompatActivity() {
     private var isCoverFlowTouching: Boolean = false
     private var lastCoverFlowScrollXForSnap: Int = 0
     private var isSettingsOverlayAnimating: Boolean = false
+    private var currentSettingsTab: SettingsTab = SettingsTab.UI
+    private var isColoredLogoEnabled: Boolean = true
     private var isSyncingAppProfileSwitches: Boolean = false
     private var isSyncingAppProfileDefaultSwitch: Boolean = false
     private var pendingPresetArtworkIndex: Int? = null
@@ -235,6 +283,61 @@ class MainActivity : AppCompatActivity() {
     private val colorPickerDialog = ColorPickerDialog()
     private val ragnarokWarningDialog = RagnarokWarningDialog()
     private lateinit var appProfileManager: AppProfileManager
+    private val builtInThemes = listOf(
+        UiTheme(
+            id = "classic",
+            label = "Classic",
+            backgroundColor = Color.parseColor("#0A0E1A"),
+            cardColor = Color.parseColor("#12182B"),
+            surfaceColor = Color.parseColor("#1A2236"),
+            textColor = Color.parseColor("#E8EEFF"),
+            accentColor = Color.parseColor("#6366F1"),
+            accentLightColor = Color.parseColor("#818CF8"),
+            headerPalette = HeaderThemePalette(
+                introHueStart = 0f,
+                introHueSpan = 360f,
+                introSaturation = 0.82f,
+                introValue = 1f,
+                settleHueStart = 18f,
+                settleHueSpan = 300f,
+                settleHueWobbleAmplitude = 10f,
+                settleSaturationBase = 0.28f,
+                settleSaturationWave = 0.14f,
+                settleValueBase = 0.92f,
+                settleValueWave = 0.08f,
+                settleAlphaBase = 224,
+                settleAlphaWave = 31,
+                settlePhaseDegrees = 18f
+            )
+        ),
+        UiTheme(
+            id = "oled_purple",
+            label = "OLED Purple",
+            backgroundColor = Color.parseColor("#000000"),
+            cardColor = Color.parseColor("#000000"),
+            surfaceColor = Color.parseColor("#000000"),
+            textColor = Color.parseColor("#C084FC"),
+            accentColor = Color.parseColor("#A855F7"),
+            accentLightColor = Color.parseColor("#C084FC"),
+            headerPalette = HeaderThemePalette(
+                introHueStart = 264f,
+                introHueSpan = 64f,
+                introSaturation = 0.9f,
+                introValue = 0.98f,
+                settleHueStart = 272f,
+                settleHueSpan = 48f,
+                settleHueWobbleAmplitude = 5f,
+                settleSaturationBase = 0.5f,
+                settleSaturationWave = 0.16f,
+                settleValueBase = 0.76f,
+                settleValueWave = 0.2f,
+                settleAlphaBase = 236,
+                settleAlphaWave = 19,
+                settlePhaseDegrees = 12f
+            )
+        )
+    )
+    private var selectedUiTheme: UiTheme = builtInThemes.first()
 
     private val launchNotificationPermissionLauncher =
         registerForActivityResult(ActivityResultContracts.RequestPermission()) { isGranted ->
@@ -406,6 +509,9 @@ class MainActivity : AppCompatActivity() {
         homeContainer = findViewById(R.id.homeContainer)
         homeSettingsButton = findViewById(R.id.homeSettingsButton)
         closeSettingsButton = findViewById(R.id.closeSettingsButton)
+        tabUiSettings = findViewById(R.id.tabUiSettings)
+        tabBehaviorSettings = findViewById(R.id.tabBehaviorSettings)
+        tabThemesSettings = findViewById(R.id.tabThemesSettings)
         presetCoverFlowScroll = findViewById(R.id.presetCoverFlowScroll)
         presetCoverFlowContainer = findViewById(R.id.presetCoverFlowContainer)
         activePresetInfoCard = findViewById(R.id.activePresetInfoCard)
@@ -421,6 +527,7 @@ class MainActivity : AppCompatActivity() {
         animationSpinner = findViewById(R.id.animationSpinner)
         profileSpinner = findViewById(R.id.profileSpinner)
         presetSpinner = findViewById(R.id.presetSpinner)
+        themeSpinner = findViewById(R.id.themeSpinner)
         savePresetButton = findViewById(R.id.savePresetButton)
         modifyPresetButton = findViewById(R.id.modifyPresetButton)
         deletePresetButton = findViewById(R.id.deletePresetButton)
@@ -446,6 +553,7 @@ class MainActivity : AppCompatActivity() {
         chargingSpeedIndicatorSwitch = findViewById(R.id.chargingSpeedIndicatorSwitch)
         flashWhenReadySwitch = findViewById(R.id.flashWhenReadySwitch)
         appProfileSwitch = findViewById(R.id.appProfileSwitch)
+        coloredLogoSwitch = findViewById(R.id.coloredLogoSwitch)
         homeAppProfileSwitch = findViewById(R.id.homeAppProfileSwitch)
         val appProfileDefaultSwitchId = resources.getIdentifier(
             "appProfileDefaultSwitch",
@@ -457,12 +565,16 @@ class MainActivity : AppCompatActivity() {
         assignAppButton = findViewById(R.id.assignAppButton)
         manageAppsButton = findViewById(R.id.manageAppsButton)
         modeCard = findViewById(R.id.modeCard)
+        appProfileCard = findViewById(R.id.appProfileCard)
         colorCard = findViewById(R.id.colorCard)
         animationCard = findViewById(R.id.animationCard)
         performanceCard = findViewById(R.id.performanceCard)
+        themesCard = findViewById(R.id.themesCard)
+        settingsSystemStatusCard = findViewById(R.id.settingsSystemStatusCard)
         systemStatusContainer = findViewById(R.id.systemStatusContainer)
         bifrostLogoView = findViewById(R.id.homeBifrostLogoView)
         bifrostTitleText = findViewById(R.id.homeBifrostTitleText)
+        bifrostTitleLabel = bifrostTitleText.text.toString()
 
         serviceController = ServiceController(
             activity = this,
@@ -496,6 +608,10 @@ class MainActivity : AppCompatActivity() {
         setupPluggedBatteryOverrideSwitch()
         setupPersistentNotificationSwitch()
         setupThorScreenPreference()
+        setupSettingsTabs()
+        setupThemeFeature()
+        setupColoredLogoSwitch()
+        setupRainbowTitleText()
         setupPresetFeature()
         updateParameterVisibility()
         enableRainbowBackground(LEDService.isRunning)
@@ -575,6 +691,174 @@ class MainActivity : AppCompatActivity() {
                     scheduleCoverFlowSnap()
                 }
             }
+        }
+    }
+
+    private fun setupSettingsTabs() {
+        tabUiSettings.setOnClickListener { setSettingsTab(SettingsTab.UI) }
+        tabBehaviorSettings.setOnClickListener { setSettingsTab(SettingsTab.BEHAVIOR) }
+        tabThemesSettings.setOnClickListener { setSettingsTab(SettingsTab.THEMES) }
+        setSettingsTab(currentSettingsTab)
+    }
+
+    private fun setSettingsTab(tab: SettingsTab) {
+        currentSettingsTab = tab
+        val showingUi = tab == SettingsTab.UI
+        val showingBehavior = tab == SettingsTab.BEHAVIOR
+        val showingThemes = tab == SettingsTab.THEMES
+
+        modeCard.visibility = if (showingUi) View.VISIBLE else View.GONE
+        colorCard.visibility = if (showingUi) View.VISIBLE else View.GONE
+        animationCard.visibility = if (showingUi) View.VISIBLE else View.GONE
+        performanceCard.visibility = if (showingUi) View.VISIBLE else View.GONE
+
+        settingsSystemStatusCard.visibility = if (showingBehavior) View.VISIBLE else View.GONE
+        appProfileCard.visibility = if (showingBehavior) View.VISIBLE else View.GONE
+
+        val thorCard = findViewById<View>(R.id.thorSettingsCard)
+        thorCard?.visibility = if (showingBehavior && DeviceInfo.isAynThor) View.VISIBLE else View.GONE
+
+        themesCard.visibility = if (showingThemes) View.VISIBLE else View.GONE
+
+        updateSettingsTabButtonStyles()
+    }
+
+    private fun updateSettingsTabButtonStyles() {
+        updateSettingsTabButtonState(tabUiSettings, currentSettingsTab == SettingsTab.UI)
+        updateSettingsTabButtonState(tabBehaviorSettings, currentSettingsTab == SettingsTab.BEHAVIOR)
+        updateSettingsTabButtonState(tabThemesSettings, currentSettingsTab == SettingsTab.THEMES)
+    }
+
+    private fun updateSettingsTabButtonState(button: MaterialButton, selected: Boolean) {
+        val selectedTint = ColorStateList.valueOf(selectedUiTheme.accentColor)
+        val unselectedTint = ColorStateList.valueOf(selectedUiTheme.surfaceColor)
+        button.backgroundTintList = if (selected) selectedTint else unselectedTint
+        button.setTextColor(if (selected) Color.WHITE else selectedUiTheme.textColor)
+        button.strokeColor = ColorStateList.valueOf(selectedUiTheme.accentLightColor)
+    }
+
+    private fun setupThemeFeature() {
+        val adapter = ArrayAdapter(this, R.layout.item_spinner_bifrost, builtInThemes.map { it.label })
+        adapter.setDropDownViewResource(R.layout.item_spinner_dropdown_bifrost)
+        themeSpinner.adapter = adapter
+
+        val selectedThemeId = prefs.getString(PREF_SELECTED_UI_THEME, builtInThemes.first().id)
+        val selectedIndex = builtInThemes.indexOfFirst { it.id == selectedThemeId }.takeIf { it >= 0 } ?: 0
+        selectedUiTheme = builtInThemes[selectedIndex]
+        themeSpinner.setSelection(selectedIndex, false)
+        applySelectedTheme(selectedUiTheme, persistSelection = false)
+
+        themeSpinner.onItemSelectedListener = object : AdapterView.OnItemSelectedListener {
+            override fun onItemSelected(parent: AdapterView<*>?, view: View?, position: Int, id: Long) {
+                val theme = builtInThemes.getOrNull(position) ?: return
+                applySelectedTheme(theme, persistSelection = true)
+            }
+
+            override fun onNothingSelected(parent: AdapterView<*>?) {}
+        }
+    }
+
+    private fun applySelectedTheme(theme: UiTheme, persistSelection: Boolean) {
+        selectedUiTheme = theme
+        if (persistSelection) {
+            prefs.edit().putString(PREF_SELECTED_UI_THEME, theme.id).apply()
+        }
+        applyUiTheme(theme)
+    }
+
+    private fun applyUiTheme(theme: UiTheme) {
+        setupStatusBar()
+        findViewById<View>(android.R.id.content)?.setBackgroundColor(theme.backgroundColor)
+        homeContainer.setBackgroundColor(theme.backgroundColor)
+        settingsOverlay.setBackgroundColor(theme.backgroundColor)
+        applyThemeToViewTree(homeContainer, theme)
+        applyThemeToViewTree(settingsOverlay, theme)
+        applyHeaderLogoPreference()
+        updateSettingsTabButtonStyles()
+    }
+
+    private fun applyThemeToViewTree(view: View, theme: UiTheme) {
+        when (view) {
+            is MaterialCardView -> {
+                view.setCardBackgroundColor(theme.cardColor)
+                view.strokeColor = theme.accentColor
+            }
+
+            is MaterialButton -> {
+                view.backgroundTintList = ColorStateList.valueOf(theme.surfaceColor)
+                view.setTextColor(theme.textColor)
+                view.iconTint = ColorStateList.valueOf(theme.textColor)
+                view.strokeColor = ColorStateList.valueOf(theme.accentColor)
+            }
+        }
+
+        if (view is ViewGroup) {
+            for (index in 0 until view.childCount) {
+                applyThemeToViewTree(view.getChildAt(index), theme)
+            }
+        }
+    }
+
+    private fun setupColoredLogoSwitch() {
+        isColoredLogoEnabled = prefs.getBoolean(PREF_COLORED_LOGO_ENABLED, true)
+        coloredLogoSwitch.isChecked = isColoredLogoEnabled
+        applyHeaderLogoPreference()
+
+        coloredLogoSwitch.setOnCheckedChangeListener { _, isChecked ->
+            isColoredLogoEnabled = isChecked
+            prefs.edit().putBoolean(PREF_COLORED_LOGO_ENABLED, isChecked).apply()
+            applyHeaderLogoPreference()
+            if (isChecked) {
+                playBifrostHeaderAnimation()
+            }
+        }
+    }
+
+    private fun setupRainbowTitleText() {
+        if (bifrostTitleLabel.isBlank()) return
+
+        bifrostLogoView.setOnClickListener {
+            if (isColoredLogoEnabled) {
+                playBifrostHeaderAnimation()
+            }
+        }
+        bifrostTitleText.setOnClickListener {
+            if (isColoredLogoEnabled) {
+                playBifrostHeaderAnimation()
+            }
+        }
+
+        if (isColoredLogoEnabled) {
+            playBifrostHeaderAnimation()
+        } else {
+            applyHeaderLogoPreference()
+        }
+    }
+
+    private fun applyHeaderLogoPreference() {
+        if (bifrostTitleLabel.isBlank()) return
+
+        titleIntroAnimator?.cancel()
+        headerSettleAnimator?.cancel()
+        titleIntroAnimator = null
+        headerSettleAnimator = null
+
+        bifrostLogoView.rotation = 0f
+        bifrostLogoView.scaleX = 1f
+        bifrostLogoView.scaleY = 1f
+        bifrostLogoView.translationY = 0f
+        bifrostLogoView.alpha = 1f
+
+        if (isColoredLogoEnabled) {
+            applyWatercolorTitlePhase(
+                bifrostTitleLabel,
+                selectedUiTheme.headerPalette.settlePhaseDegrees
+            )
+            bifrostLogoView.clearColorFilter()
+        } else {
+            bifrostTitleText.text = bifrostTitleLabel
+            bifrostTitleText.setTextColor(selectedUiTheme.textColor)
+            bifrostLogoView.clearColorFilter()
         }
     }
 
@@ -1643,7 +1927,7 @@ class MainActivity : AppCompatActivity() {
     }
 
     private fun setupStatusBar() {
-        window.statusBarColor = getColor(R.color.bifrost_bg)
+        window.statusBarColor = selectedUiTheme.backgroundColor
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
             WindowCompat.getInsetsController(window, window.decorView).apply {
                 isAppearanceLightStatusBars = false
@@ -1713,15 +1997,58 @@ class MainActivity : AppCompatActivity() {
         rainbowDrawable = null
     }
 
+    private fun normalizedCyclePhase(phaseDegrees: Float): Float {
+        return ((phaseDegrees % 360f) + 360f) % 360f / 360f
+    }
+
+    private fun computeIntroThemeColor(index: Int, maxIndex: Int, phaseDegrees: Float): Int {
+        val palette = selectedUiTheme.headerPalette
+        val phase = normalizedCyclePhase(phaseDegrees)
+        val letterProgress = index / maxIndex.toFloat()
+        val hueWindow = palette.introHueSpan * ((phase + letterProgress) % 1f)
+        val hue = (palette.introHueStart + hueWindow) % 360f
+        return Color.HSVToColor(floatArrayOf(hue, palette.introSaturation, palette.introValue))
+    }
+
+    private fun computeSettleThemeColor(index: Int, maxIndex: Int, phaseDegrees: Float): Int {
+        val palette = selectedUiTheme.headerPalette
+        val phase = normalizedCyclePhase(phaseDegrees)
+        val letterProgress = index / maxIndex.toFloat()
+        val hueProgress = (letterProgress + phase) % 1f
+        val hue = (
+            palette.settleHueStart +
+                palette.settleHueSpan * hueProgress +
+                palette.settleHueWobbleAmplitude * sin(letterProgress * PI).toFloat()
+            ) % 360f
+        val saturation = (
+            palette.settleSaturationBase +
+                palette.settleSaturationWave * ((sin(letterProgress * PI * 3.0) + 1.0) / 2.0).toFloat()
+            ).coerceIn(0f, 1f)
+        val value = (
+            palette.settleValueBase +
+                palette.settleValueWave * ((cos(letterProgress * PI * 2.0) + 1.0) / 2.0).toFloat()
+            ).coerceIn(0f, 1f)
+        val alpha = (
+            palette.settleAlphaBase +
+                palette.settleAlphaWave * ((sin(letterProgress * PI * 2.5) + 1.0) / 2.0)
+            ).roundToInt().coerceIn(0, 255)
+        return Color.HSVToColor(alpha, floatArrayOf(hue, saturation, value))
+    }
+
     private fun applyRainbowTitlePhase(text: String, phaseDegrees: Float) {
+        if (!isColoredLogoEnabled) {
+            bifrostTitleText.text = text
+            bifrostTitleText.setTextColor(selectedUiTheme.textColor)
+            return
+        }
+
         val rainbowText = SpannableString(text)
         val maxIndex = (text.length - 1).coerceAtLeast(1)
 
         text.indices.forEach { index ->
             if (text[index].isWhitespace()) return@forEach
 
-            val hue = (phaseDegrees + (360f * index / maxIndex)) % 360f
-            val color = Color.HSVToColor(floatArrayOf(hue, 0.82f, 1f))
+            val color = computeIntroThemeColor(index, maxIndex, phaseDegrees)
             rainbowText.setSpan(
                 ForegroundColorSpan(color),
                 index,
@@ -1733,8 +2060,31 @@ class MainActivity : AppCompatActivity() {
         bifrostTitleText.text = rainbowText
     }
 
+    private fun applyWatercolorTitlePhase(text: String, phaseDegrees: Float) {
+        val watercolorText = SpannableString(text)
+        val maxIndex = (text.length - 1).coerceAtLeast(1)
+
+        text.indices.forEach { index ->
+            if (text[index].isWhitespace()) return@forEach
+
+            val color = computeSettleThemeColor(index, maxIndex, phaseDegrees)
+            watercolorText.setSpan(
+                ForegroundColorSpan(color),
+                index,
+                index + 1,
+                Spanned.SPAN_EXCLUSIVE_EXCLUSIVE
+            )
+        }
+
+        bifrostTitleText.text = watercolorText
+    }
+
     private fun playBifrostHeaderAnimation() {
         if (bifrostTitleLabel.isBlank()) return
+        if (!isColoredLogoEnabled) {
+            applyHeaderLogoPreference()
+            return
+        }
 
         titleIntroAnimator?.cancel()
         headerSettleAnimator?.cancel()
@@ -1782,8 +2132,16 @@ class MainActivity : AppCompatActivity() {
     private fun resetBifrostHeaderAnimationState() {
         if (bifrostTitleLabel.isBlank()) return
 
-        bifrostTitleText.text = bifrostTitleLabel
-        bifrostTitleText.setTextColor(ContextCompat.getColor(this, R.color.bifrost_text))
+        if (isColoredLogoEnabled) {
+            applyWatercolorTitlePhase(
+                bifrostTitleLabel,
+                selectedUiTheme.headerPalette.settlePhaseDegrees
+            )
+        } else {
+            bifrostTitleText.text = bifrostTitleLabel
+            bifrostTitleText.setTextColor(selectedUiTheme.textColor)
+        }
+
         bifrostLogoView.rotation = 0f
         bifrostLogoView.scaleX = 1f
         bifrostLogoView.scaleY = 1f
@@ -1807,7 +2165,7 @@ class MainActivity : AppCompatActivity() {
             .setDuration(400L)
             .setInterpolator(DecelerateInterpolator())
             .withEndAction {
-                resetBifrostHeaderAnimationState()
+                applyHeaderLogoPreference()
             }
             .start()
     }

--- a/app/src/main/java/com/moonbench/bifrost/ThemeArchiveTransfer.kt
+++ b/app/src/main/java/com/moonbench/bifrost/ThemeArchiveTransfer.kt
@@ -1,0 +1,99 @@
+package com.moonbench.bifrost
+
+import android.content.Context
+import android.net.Uri
+import org.json.JSONObject
+
+object ThemeArchiveTransfer {
+
+    private const val THEME_SCHEMA = "bifrost_theme_bundle"
+    private const val THEME_VERSION = 1
+
+    data class ExportResult(
+        val themeId: String,
+        val warnings: List<String>
+    )
+
+    data class ImportResult(
+        val themeId: String?,
+        val coloredLogoEnabled: Boolean,
+        val warnings: List<String>,
+        val errors: List<String>
+    )
+
+    fun exportToUri(
+        context: Context,
+        uri: Uri,
+        themeId: String,
+        coloredLogoEnabled: Boolean
+    ): ExportResult {
+        val payload = JSONObject().apply {
+            put("schema", THEME_SCHEMA)
+            put("version", THEME_VERSION)
+            put("themeId", themeId)
+            put("coloredLogoEnabled", coloredLogoEnabled)
+        }
+
+        context.contentResolver.openOutputStream(uri)?.use { stream ->
+            stream.writer(Charsets.UTF_8).use { writer ->
+                writer.write(payload.toString(2))
+            }
+        } ?: return ExportResult(
+            themeId = themeId,
+            warnings = listOf("Unable to write selected file.")
+        )
+
+        return ExportResult(
+            themeId = themeId,
+            warnings = emptyList()
+        )
+    }
+
+    fun importFromUri(context: Context, uri: Uri): ImportResult {
+        val warnings = mutableListOf<String>()
+        val errors = mutableListOf<String>()
+
+        val rawJson = context.contentResolver.openInputStream(uri)?.use { input ->
+            input.bufferedReader(Charsets.UTF_8).use { reader ->
+                reader.readText()
+            }
+        } ?: return ImportResult(
+            themeId = null,
+            coloredLogoEnabled = true,
+            warnings = emptyList(),
+            errors = listOf("Unable to read selected file.")
+        )
+
+        val payload = runCatching { JSONObject(rawJson) }.getOrElse {
+            return ImportResult(
+                themeId = null,
+                coloredLogoEnabled = true,
+                warnings = emptyList(),
+                errors = listOf("Theme file is invalid JSON")
+            )
+        }
+
+        if (payload.optString("schema") != THEME_SCHEMA) {
+            errors += "Unknown theme bundle schema."
+        }
+
+        val version = payload.optInt("version", -1)
+        if (version < 1) {
+            errors += "Unsupported theme bundle version: $version"
+        } else if (version > THEME_VERSION) {
+            warnings += "Theme bundle version $version is newer than supported version $THEME_VERSION. Attempting compatible import."
+        }
+
+        val themeId = payload.optString("themeId").takeIf { it.isNotBlank() }
+        if (themeId == null) {
+            errors += "Theme bundle does not specify a theme."
+        }
+
+        return ImportResult(
+            themeId = themeId,
+            coloredLogoEnabled = payload.optBoolean("coloredLogoEnabled", true),
+            warnings = warnings,
+            errors = errors
+        )
+    }
+}

--- a/app/src/main/java/com/moonbench/bifrost/presets/PresetVisuals.kt
+++ b/app/src/main/java/com/moonbench/bifrost/presets/PresetVisuals.kt
@@ -105,6 +105,26 @@ object PresetImageStorage {
     private const val MAX_IMAGE_BYTES = 8L * 1024L * 1024L
     private val SAFE_FILE_NAME_REGEX = Regex("^[A-Za-z0-9._-]{1,96}$")
 
+    fun listStoredIconFileNames(context: Context): List<String> {
+        val dir = resolveDirectory(context)
+        return dir.listFiles()
+            ?.asSequence()
+            ?.filter { it.isFile }
+            ?.map { it.name }
+            ?.sorted()
+            ?.toList()
+            ?: emptyList()
+    }
+
+    fun clearAllIcons(context: Context) {
+        val dir = resolveDirectory(context)
+        dir.listFiles()?.forEach { file ->
+            if (file.isFile) {
+                file.delete()
+            }
+        }
+    }
+
     fun copyPickedImage(context: Context, sourceUri: Uri): String? {
         val mimeType = context.contentResolver.getType(sourceUri)?.lowercase() ?: return null
         if (!mimeType.startsWith("image/")) return null
@@ -174,6 +194,16 @@ object PresetImageStorage {
             FileOutputStream(targetFile).use { it.write(bytes) }
             targetFile.name
         }.getOrNull()
+    }
+
+    fun writeIconWithExactName(context: Context, fileName: String, bytes: ByteArray): Boolean {
+        if (bytes.isEmpty() || bytes.size > MAX_IMAGE_BYTES) return false
+
+        return runCatching {
+            val targetFile = resolveFile(context, fileName)
+            FileOutputStream(targetFile).use { it.write(bytes) }
+            true
+        }.getOrDefault(false)
     }
 
     fun loadBitmap(context: Context, fileName: String, targetSizePx: Int): Bitmap? {

--- a/app/src/main/java/com/moonbench/bifrost/services/LEDService.kt
+++ b/app/src/main/java/com/moonbench/bifrost/services/LEDService.kt
@@ -13,6 +13,8 @@ import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
 import android.content.pm.PackageManager
+import android.database.ContentObserver
+import android.provider.Settings
 import android.content.pm.ServiceInfo
 import android.graphics.BitmapFactory
 import android.graphics.Color
@@ -74,6 +76,10 @@ class LEDService : Service() {
         const val EXTRA_ALLOW_BACKGROUND_RUN = "allowBackgroundRun"
         const val EXTRA_BATTERY_OVERRIDE_WHEN_PLUGGED = "batteryOverrideWhenPlugged"
         const val EXTRA_PERSISTENT_NOTIFICATION = "persistentNotification"
+        const val EXTRA_ADAPTIVE_BRIGHTNESS = "adaptiveBrightness"
+
+        /** Minimum LED scale applied when screen brightness is at its lowest (0–255 → 0.25). */
+        private const val ADAPTIVE_BRIGHTNESS_MIN_SCALE = 0.25f
         private const val EXTRA_BATTERY_LOW_COLOR_OVERRIDE = "batteryLowColorOverride"
         private const val EXTRA_BATTERY_MID_COLOR_OVERRIDE = "batteryMidColorOverride"
         private const val EXTRA_BATTERY_HIGH_COLOR_OVERRIDE = "batteryHighColorOverride"
@@ -117,6 +123,7 @@ class LEDService : Service() {
     private var currentCpuHotColorOverride: Int? = null
     private var currentBatteryOverrideWhenPlugged: Boolean = false
     private var currentPersistentNotification: Boolean = true
+    private var currentAdaptiveBrightness: Boolean = false
     private var allowBackgroundRun: Boolean = false
     private var currentAmbilightDisplayId: Int = Display.DEFAULT_DISPLAY
     private var activeAnimationType: LedAnimationType? = null
@@ -128,6 +135,46 @@ class LEDService : Service() {
     private var pendingProjectionRunnable: Runnable? = null
     private var pendingShutdownRunnable: Runnable? = null
     private var isAppProfileSuppressed: Boolean = false
+
+    /**
+     * Maps the current system screen brightness (0–255) to an LED brightness multiplier.
+     * Brightness 0 → ADAPTIVE_BRIGHTNESS_MIN_SCALE, brightness 255 → 1.0.
+     */
+    private val screenBrightnessObserver = object : ContentObserver(Handler(Looper.getMainLooper())) {
+        override fun onChange(selfChange: Boolean) {
+            if (!currentAdaptiveBrightness) return
+            applyAdaptiveBrightnessToAnimation()
+        }
+    }
+
+    private fun screenBrightnessScale(): Float {
+        val raw = runCatching {
+            Settings.System.getInt(contentResolver, Settings.System.SCREEN_BRIGHTNESS)
+        }.getOrDefault(255)
+        val normalised = raw.coerceIn(0, 255) / 255f
+        return ADAPTIVE_BRIGHTNESS_MIN_SCALE + normalised * (1f - ADAPTIVE_BRIGHTNESS_MIN_SCALE)
+    }
+
+    private fun effectiveBrightness(): Int {
+        if (!currentAdaptiveBrightness) return currentBrightness
+        return (currentBrightness * screenBrightnessScale()).toInt().coerceIn(0, 255)
+    }
+
+    private fun applyAdaptiveBrightnessToAnimation() {
+        currentAnimation?.setTargetBrightness(effectiveBrightness())
+    }
+
+    private fun mountScreenBrightnessObserver() {
+        contentResolver.registerContentObserver(
+            Settings.System.getUriFor(Settings.System.SCREEN_BRIGHTNESS),
+            false,
+            screenBrightnessObserver
+        )
+    }
+
+    private fun unmountScreenBrightnessObserver() {
+        runCatching { contentResolver.unregisterContentObserver(screenBrightnessObserver) }
+    }
 
     private val batteryStateReceiver = object : BroadcastReceiver() {
         override fun onReceive(context: Context?, intent: Intent?) {
@@ -173,6 +220,7 @@ class LEDService : Service() {
         ledController = LedController()
         registerBatteryStateReceiver()
         refreshPluggedStateSnapshot()
+        mountScreenBrightnessObserver()
         handler.post(activityCheckRunnable)
     }
 
@@ -213,6 +261,10 @@ class LEDService : Service() {
         currentPersistentNotification = intent.getBooleanExtra(
             EXTRA_PERSISTENT_NOTIFICATION,
             currentPersistentNotification
+        )
+        currentAdaptiveBrightness = intent.getBooleanExtra(
+            EXTRA_ADAPTIVE_BRIGHTNESS,
+            currentAdaptiveBrightness
         )
 
         val notification = createNotification()
@@ -284,6 +336,7 @@ class LEDService : Service() {
         currentSensitivity = sensitivity
         isAppProfileSuppressed = false
 
+
         refreshPluggedStateSnapshot()
 
         if (appProfileManager.isEnabled) {
@@ -323,7 +376,15 @@ class LEDService : Service() {
         if (intent.hasExtra("brightness")) {
             val newBrightness = intent.getIntExtra("brightness", currentBrightness).coerceIn(0, 255)
             currentBrightness = newBrightness
-            animation?.setTargetBrightness(currentBrightness)
+            animation?.setTargetBrightness(effectiveBrightness())
+        }
+
+        if (intent.hasExtra(EXTRA_ADAPTIVE_BRIGHTNESS)) {
+            val newAdaptive = intent.getBooleanExtra(EXTRA_ADAPTIVE_BRIGHTNESS, currentAdaptiveBrightness)
+            if (newAdaptive != currentAdaptiveBrightness) {
+                currentAdaptiveBrightness = newAdaptive
+                animation?.setTargetBrightness(effectiveBrightness())
+            }
         }
 
         if (intent.hasExtra("speed")) {
@@ -591,6 +652,9 @@ class LEDService : Service() {
         pendingProjectionRunnable?.let(handler::removeCallbacks)
         pendingProjectionRunnable = null
 
+        // Apply adaptive brightness scaling on top of the user-configured brightness level.
+        val resolvedBrightness = effectiveBrightness()
+
         stopCurrentAnimation()
 
         if (needsMediaProjection(animationType) && resultCode == Activity.RESULT_OK && data != null) {
@@ -603,7 +667,7 @@ class LEDService : Service() {
                             try {
                                 if (isRunning && !isStopping.get()) {
                                     replaceMediaProjection(resultCode, data)
-                                    startAnimation(animationType, color, rightColor, brightness, speed, smoothness, sensitivity, profile, currentSaturationBoost)
+                                    startAnimation(animationType, color, rightColor, resolvedBrightness, speed, smoothness, sensitivity, profile, currentSaturationBoost)
                                 }
                             } catch (e: Exception) {
                                 e.printStackTrace()
@@ -629,7 +693,7 @@ class LEDService : Service() {
         } else {
             pendingTransitionRunnable = Runnable {
                 if (isRunning && !isStopping.get()) {
-                    startAnimation(animationType, color, rightColor, brightness, speed, smoothness, sensitivity, profile, currentSaturationBoost)
+                    startAnimation(animationType, color, rightColor, resolvedBrightness, speed, smoothness, sensitivity, profile, currentSaturationBoost)
                 }
                 isTransitioning.set(false)
                 pendingTransitionRunnable = null
@@ -784,6 +848,7 @@ class LEDService : Service() {
         handler.removeCallbacks(activityCheckRunnable)
         clearPendingCallbacks()
         unregisterBatteryStateReceiver()
+        unmountScreenBrightnessObserver()
         cleanupAndStop()
     }
 

--- a/app/src/main/java/com/moonbench/bifrost/services/LEDService.kt
+++ b/app/src/main/java/com/moonbench/bifrost/services/LEDService.kt
@@ -134,6 +134,7 @@ class LEDService : Service() {
     private var pendingTransitionRunnable: Runnable? = null
     private var pendingProjectionRunnable: Runnable? = null
     private var pendingShutdownRunnable: Runnable? = null
+    private var pendingFinalizeStopRunnable: Runnable? = null
     private var isAppProfileSuppressed: Boolean = false
 
     /**
@@ -252,6 +253,10 @@ class LEDService : Service() {
             handleSupplyProjection(intent)
             return START_NOT_STICKY
         }
+
+        // A new start intent can arrive while a delayed shutdown is still pending.
+        // Cancel pending teardown so we don't stop immediately after restarting.
+        reviveIfStopping()
 
         allowBackgroundRun = intent.getBooleanExtra(EXTRA_ALLOW_BACKGROUND_RUN, allowBackgroundRun)
         currentBatteryOverrideWhenPlugged = intent.getBooleanExtra(
@@ -859,6 +864,14 @@ class LEDService : Service() {
         pendingProjectionRunnable = null
         pendingShutdownRunnable?.let(handler::removeCallbacks)
         pendingShutdownRunnable = null
+        pendingFinalizeStopRunnable?.let(handler::removeCallbacks)
+        pendingFinalizeStopRunnable = null
+    }
+
+    private fun reviveIfStopping() {
+        if (!isStopping.get()) return
+        clearPendingCallbacks()
+        isStopping.set(false)
     }
 
     private fun cleanupAndStop() {
@@ -885,11 +898,13 @@ class LEDService : Service() {
 
                 try {
                     ledController.setLedColor(0, 0, 0, 0, true, true, true, true)
-                    handler.postDelayed({
+                    pendingFinalizeStopRunnable = Runnable {
                         runCatching { ledController.shutdown() }
                         stopForeground(STOP_FOREGROUND_REMOVE)
                         stopSelf()
-                    }, LED_OFF_SETTLE_DELAY_MS)
+                        pendingFinalizeStopRunnable = null
+                    }
+                    handler.postDelayed(pendingFinalizeStopRunnable!!, LED_OFF_SETTLE_DELAY_MS)
                 } catch (e: Exception) {
                     e.printStackTrace()
                     stopForeground(STOP_FOREGROUND_REMOVE)

--- a/app/src/main/java/com/moonbench/bifrost/services/ServiceController.kt
+++ b/app/src/main/java/com/moonbench/bifrost/services/ServiceController.kt
@@ -17,6 +17,7 @@ class ServiceController(
     private var isOperationInProgress = false
     private var lastOperationTime = 0L
     private var pendingServiceOperation: Runnable? = null
+    private var pendingTransitionClear: Runnable? = null
     private var operationToken = 0
 
     var onNeedsMediaProjectionCheck: (() -> Unit)? = null
@@ -24,6 +25,8 @@ class ServiceController(
     fun cancelPendingOperations() {
         pendingServiceOperation?.let { handler.removeCallbacks(it) }
         pendingServiceOperation = null
+        pendingTransitionClear?.let { handler.removeCallbacks(it) }
+        pendingTransitionClear = null
         isOperationInProgress = false
         isServiceTransitioning = false
         operationToken++
@@ -42,13 +45,19 @@ class ServiceController(
 
     private fun finishOperationWindowWithGraceDelay() {
         isOperationInProgress = false
-        handler.postDelayed({
-            isServiceTransitioning = false
-        }, 200)
+        val token = operationToken
+        pendingTransitionClear?.let { handler.removeCallbacks(it) }
+        pendingTransitionClear = Runnable {
+            if (token == operationToken) {
+                isServiceTransitioning = false
+            }
+            pendingTransitionClear = null
+        }
+        handler.postDelayed(pendingTransitionClear!!, 200)
     }
 
     fun startDebounced(createIntent: () -> Intent) {
-        if (isOperationInProgress) return
+        if (isOperationInProgress) cancelPendingOperations()
         beginOperationWindow()
         val token = operationToken
 
@@ -65,7 +74,7 @@ class ServiceController(
     }
 
     fun stopDebounced() {
-        if (isOperationInProgress) return
+        if (isOperationInProgress) cancelPendingOperations()
         beginOperationWindow()
         val token = operationToken
 
@@ -82,7 +91,7 @@ class ServiceController(
     }
 
     fun restartDebounced(needsMediaProjectionCheck: Boolean = false, createIntent: () -> Intent) {
-        if (isOperationInProgress) return
+        if (isOperationInProgress) cancelPendingOperations()
 
         if (needsMediaProjectionCheck) {
             onNeedsMediaProjectionCheck?.invoke()

--- a/app/src/main/res/layout/layout_settings_panel.xml
+++ b/app/src/main/res/layout/layout_settings_panel.xml
@@ -150,6 +150,59 @@
             app:strokeColor="@color/bifrost_accent" />
     </LinearLayout>
 
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="12dp"
+        android:orientation="horizontal">
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/tabUiSettings"
+            android:layout_width="0dp"
+            android:layout_height="40dp"
+            android:layout_weight="1"
+            android:layout_marginEnd="4dp"
+            android:text="UI SETTINGS"
+            android:textColor="@color/bifrost_text"
+            android:textSize="10sp"
+            android:letterSpacing="0.05"
+            android:backgroundTint="@color/bifrost_surface"
+            app:cornerRadius="10dp"
+            app:strokeWidth="1dp"
+            app:strokeColor="@color/bifrost_accent" />
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/tabBehaviorSettings"
+            android:layout_width="0dp"
+            android:layout_height="40dp"
+            android:layout_weight="1"
+            android:layout_marginStart="2dp"
+            android:layout_marginEnd="2dp"
+            android:text="BEHAVIOUR"
+            android:textColor="@color/bifrost_text"
+            android:textSize="10sp"
+            android:letterSpacing="0.05"
+            android:backgroundTint="@color/bifrost_surface"
+            app:cornerRadius="10dp"
+            app:strokeWidth="1dp"
+            app:strokeColor="@color/bifrost_accent" />
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/tabThemesSettings"
+            android:layout_width="0dp"
+            android:layout_height="40dp"
+            android:layout_weight="1"
+            android:layout_marginStart="4dp"
+            android:text="THEMES"
+            android:textColor="@color/bifrost_text"
+            android:textSize="10sp"
+            android:letterSpacing="0.05"
+            android:backgroundTint="@color/bifrost_surface"
+            app:cornerRadius="10dp"
+            app:strokeWidth="1dp"
+            app:strokeColor="@color/bifrost_accent" />
+    </LinearLayout>
+
     <ScrollView
         android:layout_width="match_parent"
         android:layout_height="0dp"
@@ -164,6 +217,7 @@
             android:orientation="vertical">
 
             <com.google.android.material.card.MaterialCardView
+                android:id="@+id/settingsSystemStatusCard"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginBottom="@dimen/bifrost_spacing_md"
@@ -1158,6 +1212,94 @@
                         android:paddingEnd="16dp"
                         android:paddingTop="12dp"
                         android:paddingBottom="12dp" />
+                </LinearLayout>
+            </com.google.android.material.card.MaterialCardView>
+
+            <com.google.android.material.card.MaterialCardView
+                android:id="@+id/themesCard"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="@dimen/bifrost_spacing_md"
+                app:cardBackgroundColor="@color/bifrost_card"
+                app:cardCornerRadius="16dp"
+                app:cardElevation="0dp"
+                android:outlineAmbientShadowColor="@color/bifrost_glow_purple"
+                android:outlineSpotShadowColor="@color/bifrost_glow_purple"
+                android:visibility="gone">
+
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="vertical"
+                    android:padding="@dimen/bifrost_card_padding"
+                    android:background="@drawable/card_glow_bg">
+
+                    <TextView
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="THEMES"
+                        android:textColor="@color/bifrost_text"
+                        android:textSize="12sp"
+                        android:letterSpacing="0.08"
+                        android:textStyle="bold" />
+
+                    <TextView
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="2dp"
+                        android:layout_marginBottom="12dp"
+                        android:text="Switch between Classic and OLED Purple palettes"
+                        android:textColor="@color/bifrost_text_secondary"
+                        android:textSize="11sp" />
+
+                    <Spinner
+                        android:id="@+id/themeSpinner"
+                        android:layout_width="match_parent"
+                        android:layout_height="48dp"
+                        android:background="@drawable/bifrost_spinner_modern"
+                        android:paddingStart="12dp"
+                        android:paddingEnd="12dp"
+                        android:paddingTop="8dp"
+                        android:paddingBottom="8dp" />
+
+                    <LinearLayout
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="12dp"
+                        android:orientation="horizontal"
+                        android:gravity="center_vertical">
+
+                        <LinearLayout
+                            android:layout_width="0dp"
+                            android:layout_height="wrap_content"
+                            android:layout_weight="1"
+                            android:orientation="vertical">
+
+                            <TextView
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:text="COLOURED LOGO"
+                                android:textColor="@color/bifrost_text"
+                                android:textSize="12sp"
+                                android:letterSpacing="0.05"
+                                android:textStyle="bold" />
+
+                            <TextView
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:layout_marginTop="2dp"
+                                android:text="Toggle animated color treatment for the Bifrost logo/title"
+                                android:textColor="@color/bifrost_text_secondary"
+                                android:textSize="11sp" />
+                        </LinearLayout>
+
+                        <com.google.android.material.switchmaterial.SwitchMaterial
+                            android:id="@+id/coloredLogoSwitch"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            app:thumbTint="@color/switch_thumb_tint"
+                            app:trackTint="@color/switch_track_tint" />
+                    </LinearLayout>
                 </LinearLayout>
             </com.google.android.material.card.MaterialCardView>
 

--- a/app/src/main/res/layout/layout_settings_panel.xml
+++ b/app/src/main/res/layout/layout_settings_panel.xml
@@ -125,7 +125,7 @@
             android:layout_height="40dp"
             android:layout_weight="1"
             android:layout_marginEnd="4dp"
-            android:text="EXPORT"
+            android:text="BACKUP"
             android:textSize="11sp"
             android:letterSpacing="0.05"
             android:textColor="@color/bifrost_text"
@@ -140,7 +140,7 @@
             android:layout_height="40dp"
             android:layout_weight="1"
             android:layout_marginStart="4dp"
-            android:text="IMPORT"
+            android:text="RESTORE"
             android:textSize="11sp"
             android:letterSpacing="0.05"
             android:textColor="@color/bifrost_text"
@@ -346,6 +346,45 @@
 
                         <com.google.android.material.switchmaterial.SwitchMaterial
                             android:id="@+id/persistentNotificationSwitch"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            app:thumbTint="@color/switch_thumb_tint"
+                            app:trackTint="@color/switch_track_tint" />
+                    </LinearLayout>
+
+                    <LinearLayout
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:orientation="horizontal"
+                        android:gravity="center_vertical"
+                        android:layout_marginTop="12dp">
+
+                        <LinearLayout
+                            android:layout_width="0dp"
+                            android:layout_height="wrap_content"
+                            android:layout_weight="1"
+                            android:orientation="vertical">
+
+                            <TextView
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:text="ADAPTIVE LED BRIGHTNESS"
+                                android:textColor="@color/bifrost_text"
+                                android:textSize="12sp"
+                                android:letterSpacing="0.05"
+                                android:textStyle="bold" />
+
+                            <TextView
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:text="Scale LED brightness to match screen brightness"
+                                android:textColor="@color/bifrost_text_secondary"
+                                android:textSize="11sp"
+                                android:layout_marginTop="2dp" />
+                        </LinearLayout>
+
+                        <com.google.android.material.switchmaterial.SwitchMaterial
+                            android:id="@+id/adaptiveBrightnessSwitch"
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
                             app:thumbTint="@color/switch_thumb_tint"
@@ -1261,6 +1300,43 @@
                         android:paddingEnd="12dp"
                         android:paddingTop="8dp"
                         android:paddingBottom="8dp" />
+
+                    <LinearLayout
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="12dp"
+                        android:orientation="horizontal">
+
+                        <com.google.android.material.button.MaterialButton
+                            android:id="@+id/exportThemeButton"
+                            android:layout_width="0dp"
+                            android:layout_height="40dp"
+                            android:layout_weight="1"
+                            android:layout_marginEnd="4dp"
+                            android:text="EXPORT THEME"
+                            android:textSize="11sp"
+                            android:letterSpacing="0.05"
+                            android:textColor="@color/bifrost_text"
+                            android:backgroundTint="@color/bifrost_surface"
+                            app:cornerRadius="10dp"
+                            app:strokeWidth="1dp"
+                            app:strokeColor="@color/bifrost_accent" />
+
+                        <com.google.android.material.button.MaterialButton
+                            android:id="@+id/importThemeButton"
+                            android:layout_width="0dp"
+                            android:layout_height="40dp"
+                            android:layout_weight="1"
+                            android:layout_marginStart="4dp"
+                            android:text="IMPORT THEME"
+                            android:textSize="11sp"
+                            android:letterSpacing="0.05"
+                            android:textColor="@color/bifrost_text"
+                            android:backgroundTint="@color/bifrost_surface"
+                            app:cornerRadius="10dp"
+                            app:strokeWidth="1dp"
+                            app:strokeColor="@color/bifrost_accent" />
+                    </LinearLayout>
 
                     <LinearLayout
                         android:layout_width="match_parent"


### PR DESCRIPTION
## Complete Difference Inventory (This Branch vs Upstream Main)

This PR body is intentionally exhaustive. It enumerates every difference between:
- Base: upstream/main (94ac1ae)
- Head: fix/ui-smoothness-and-service-races (061d8c5)

### 1) Changed files (name-status)

```text
A	AGENT_INSTRUCTIONS.md
M	README.md
A	app/src/main/java/com/moonbench/bifrost/BackupArchiveTransfer.kt
M	app/src/main/java/com/moonbench/bifrost/MainActivity.kt
A	app/src/main/java/com/moonbench/bifrost/ThemeArchiveTransfer.kt
M	app/src/main/java/com/moonbench/bifrost/presets/PresetVisuals.kt
M	app/src/main/java/com/moonbench/bifrost/services/LEDService.kt
M	app/src/main/java/com/moonbench/bifrost/services/ServiceController.kt
M	app/src/main/res/layout/layout_settings_panel.xml
```

### 2) Diffstat

```text
 AGENT_INSTRUCTIONS.md                              |  13 +
 README.md                                          | 201 +++---
 .../com/moonbench/bifrost/BackupArchiveTransfer.kt | 436 +++++++++++++
 .../java/com/moonbench/bifrost/MainActivity.kt     | 691 +++++++++++++++++++--
 .../com/moonbench/bifrost/ThemeArchiveTransfer.kt  |  99 +++
 .../com/moonbench/bifrost/presets/PresetVisuals.kt |  30 +
 .../com/moonbench/bifrost/services/LEDService.kt   |  90 ++-
 .../bifrost/services/ServiceController.kt          |  21 +-
 app/src/main/res/layout/layout_settings_panel.xml  | 222 ++++++-
 9 files changed, 1653 insertions(+), 150 deletions(-)
```

### 3) Full patch (line-level enumeration)

```diff
diff --git a/AGENT_INSTRUCTIONS.md b/AGENT_INSTRUCTIONS.md
new file mode 100644
index 0000000..a755c52
--- /dev/null
+++ b/AGENT_INSTRUCTIONS.md
@@ -0,0 +1,13 @@
+This document contains instructions for autonomous coding agents. 
+
+1. Use openjdk@17 when building
+2. adhere to NASA coding standards
+3. ensure that this application consumes minimal overhead
+  a. prioritize stability and performance over feature-richness
+4. ensure that lessons learned and regressions to be avoided are added to this document
+5. preserve divergent material when merging from upstream
+6. 
+  a. do not pollute or deface upstream repo
+  b. be considerate when submitting changes and ensure there are minimal conflicts
+  c. ensure that material specific to this fork (like readme differences and identifiers) are not submitted upstream
+7. theme settings that are user-facing, especially selected theme and coloured-logo state, must remain transferable independently of full backups so theme iteration does not require whole-app restore flows
diff --git a/README.md b/README.md
index 2f0c527..ee18ba4 100644
--- a/README.md
+++ b/README.md
@@ -3,2 +3,3 @@
-Bifrost is a custom LED controller for the **AYN Thor** handheld (and might work for other handhelds).  
-It provides a collection of LED animations that can run in the background, including:
+Bifrost is a custom LED controller for the **AYN Thor** handheld (and might work for other handhelds).\
+It provides a collection of LED animations that can run in the
+background, including:
@@ -11 +12 @@ It provides a collection of LED animations that can run in the background, inclu
-Bifrost aims to bring a vibrant, customizable lighting experience to the  
+Bifrost aims to bring a vibrant, customizable lighting experience to the
@@ -14,2 +15,4 @@ AYN Thor while keeping performance and battery consumption in mind.
-> ⚠️ **Important:** For animations to work, **Bifrost must stay alive in the background**.  
-> Closing the app or restricting notification (and screen recording for Ambilight) activity will stop LED updates.
+> ⚠️ **Important:** For animations to work, **Bifrost must stay alive in
+> the background**.\
+> Closing the app or restricting notification (and screen recording for Ambilight) activity will stop LED
+> updates.
@@ -17 +20 @@ AYN Thor while keeping performance and battery consumption in mind.
----
+------------------------------------------------------------------------
@@ -19 +22 @@ AYN Thor while keeping performance and battery consumption in mind.
-# ✨ Features
+## ✨ Features
@@ -21 +24 @@ AYN Thor while keeping performance and battery consumption in mind.
-## Ambilight
+### **Ambilight**
@@ -23,2 +26,4 @@ AYN Thor while keeping performance and battery consumption in mind.
-Uses Android's screen recording API to sample the screen's left and right average colors.  
-For performance, Bifrost captures the screen in **2×1 pixels** and reads the RGB values directly from the buffer.
+Uses Android's screen recording API to sample the screen's left and
+right average colors.\
+For performance, Bifrost captures the screen in **2×1 pixels** and reads
+the RGB values directly from the buffer.
@@ -26 +30,0 @@ For performance, Bifrost captures the screen in **2×1 pixels** and reads the RG
-### Options
@@ -27,0 +32 @@ For performance, Bifrost captures the screen in **2×1 pixels** and reads the RG
+**New options:**
@@ -33,2 +38,3 @@ For performance, Bifrost captures the screen in **2×1 pixels** and reads the RG
-When choosing the custom color sampler, Bifrost captures the screen using a **low-resolution 32-pixel grid**, allowing more advanced color analysis while remaining lightweight:
-
+When choosing the custom colors sampler, Bifrost captures the screen using a
+**low-resolution 32-pixel**, which allows more advanced color
+analysis while remaining lightweight, it:
@@ -38,5 +44 @@ When choosing the custom color sampler, Bifrost captures the screen using a **lo
----
-
-## Audio Reactive
-
-Analyzes live audio levels (using the screen recording permission) to drive LED intensity.
+### **Audio Reactive**
@@ -44 +46,2 @@ Analyzes live audio levels (using the screen recording permission) to drive LED
-### Improvements
+Analyzes live audio levels (using the screen recording permission) to
+drive LED intensity.
@@ -46 +49,2 @@ Analyzes live audio levels (using the screen recording permission) to drive LED
-- Redesigned **reactivity system** using a single unified reactivity slider
+**Improvements:**
+- Redesigned **reactivity system** using a single, unified reactivity slider
@@ -49,5 +53 @@ Analyzes live audio levels (using the screen recording permission) to drive LED
----
-
-## Ambi Aurora
-
-Combines Ambilight color sampling with Audio Reactive intensity for a hybrid effect.
+### **Ambi Aurora**
@@ -55 +55,2 @@ Combines Ambilight color sampling with Audio Reactive intensity for a hybrid eff
-### Enhancements
+Combines Ambilight color sampling with Audio Reactive intensity for a
+hybrid effect.
@@ -56,0 +58 @@ Combines Ambilight color sampling with Audio Reactive intensity for a hybrid eff
+**Enhancements:**
@@ -60,3 +62 @@ Combines Ambilight color sampling with Audio Reactive intensity for a hybrid eff
----
-
-## Animation Presets
+### **Animation Presets**
@@ -68,5 +68 @@ Combines Ambilight color sampling with Audio Reactive intensity for a hybrid eff
----
-
-## Performance Profiles
-
-Bifrost offers multiple performance-level modes.
+### **Performance Profiles**
@@ -74 +70,3 @@ Bifrost offers multiple performance-level modes.
-The **Ragnarok profile** updates the Thor LED controller **as fast as possible**, which may cause latency or even crashes.
+Bifrost offers multiple performance-level modes.\
+The **Ragnarok profile** updates the Thor LED controller **as fast as
+possible**, which may cause latency or even crashes.
@@ -76 +74 @@ The **Ragnarok profile** updates the Thor LED controller **as fast as possible**
----
+------------------------------------------------------------------------
@@ -78 +76 @@ The **Ragnarok profile** updates the Thor LED controller **as fast as possible**
-# 🚀 New Features
+## 🚀 New Features
@@ -82 +80 @@ Recent updates introduce several new capabilities.
-## Auto Start
+### Auto Start
@@ -87 +85 @@ Recent updates introduce several new capabilities.
-## App-based Profiles
+### App-based Profiles
@@ -95 +93 @@ Recent updates introduce several new capabilities.
-## Independent LED Control
+### Independent LED Control
@@ -100 +98 @@ Recent updates introduce several new capabilities.
-## Charging Indicator
+### Charging Indicator
@@ -108 +106 @@ Improved LED feedback while charging:
-## CPU Temperature Animation
+### CPU Temperature Animation
@@ -112 +110 @@ A new animation that changes LED colors based on **CPU temperature readings**.
-## Preset Export / Import
+### Preset Export / Import
@@ -118 +116 @@ A new animation that changes LED colors based on **CPU temperature readings**.
-## Preset Artwork and Management
+### Preset Artwork and Management
@@ -129 +127 @@ A new animation that changes LED colors based on **CPU temperature readings**.
-## Animation Color Customization
+### Animation Color Customization
@@ -135 +133 @@ A new animation that changes LED colors based on **CPU temperature readings**.
-## Service and UX Controls
+### Service and UX Controls
@@ -141 +139 @@ A new animation that changes LED colors based on **CPU temperature readings**.
----
+------------------------------------------------------------------------
@@ -143 +141 @@ A new animation that changes LED colors based on **CPU temperature readings**.
-# 📦 Installation
+## 📦 Installation
@@ -147 +145 @@ Bifrost can be installed in two different ways:
-## Method 1 — Manual APK install
+### **Method 1 — Manual APK install**
@@ -155,3 +153 @@ Bifrost can be installed in two different ways:
----
-
-## Method 2 — Install & update via Obtainium (recommended)
+### **Method 2 — Install & update via Obtainium (recommended)**
@@ -161,5 +157,5 @@ If you use **Obtainium**, you can automatically receive updates:
-1. Open the Obtainium app  
-   https://github.com/ImranR98/Obtainium
-
-2. Add a new app using this source:
-   https://github.com/Pollux-MoonBench/Bifrost/releases/
+1. Open the Obtainium app. It can be found here : https://github.com/ImranR98/Obtainium
+2. Add a new app using this fork as a source: https://github.com/KuriGohan-Kamehameha/Bifrost/releases/
+   (Optionally, Add using the original source: https://github.com/Pollux-MoonBench/Bifrost/releases/)
+3. Follow the Obtainium installation process
+------------------------------------------------------------------------
@@ -167 +163 @@ If you use **Obtainium**, you can automatically receive updates:
-3. Follow the Obtainium installation process.
+## 🔒 Required Permissions
@@ -169 +165,2 @@ If you use **Obtainium**, you can automatically receive updates:
----
+To enable Ambilight, Audio Reactive, and Ambi Aurora modes, Bifrost
+requires:
@@ -171 +168,3 @@ If you use **Obtainium**, you can automatically receive updates:
-# 🔒 Required Permissions
+- **Screen recording permission**\
+  Used exclusively to sample colors (Ambilight) and volume intensity
+  (Audio Reactive).
@@ -173 +172,2 @@ If you use **Obtainium**, you can automatically receive updates:
-To enable Ambilight, Audio Reactive, and Ambi Aurora modes, Bifrost requires:
+Bifrost does *not* save or transmit screen contents — sampling happens
+locally and is reduced to minimal pixel data for efficiency.
@@ -175 +175 @@ To enable Ambilight, Audio Reactive, and Ambi Aurora modes, Bifrost requires:
-### Screen recording permission
+------------------------------------------------------------------------
@@ -177,10 +177 @@ To enable Ambilight, Audio Reactive, and Ambi Aurora modes, Bifrost requires:
-Used exclusively to sample:
-
-- Screen colors (Ambilight)
-- Audio intensity (Audio Reactive)
-
-Bifrost does **not save or transmit screen contents** — sampling happens locally and is reduced to minimal pixel data for efficiency.
-
----
-
-# 🎮 Other Tested Devices
+## 🎮 Other Tested Devices
@@ -190 +181 @@ Bifrost has been tested and confirmed to work on the following devices:
-### AYN
+AYN
@@ -194 +185 @@ Bifrost has been tested and confirmed to work on the following devices:
-### Retroid
+Retroid
@@ -198 +189 @@ Bifrost has been tested and confirmed to work on the following devices:
----
+------------------------------------------------------------------------
@@ -200 +191 @@ Bifrost has been tested and confirmed to work on the following devices:
-# ⚠️ In Dev Status
+## ⚠️ In Dev Status
@@ -203 +194,2 @@ Bifrost is now **out of beta**, but still actively evolving.
-While overall stability has improved, unexpected behavior may still occur on some devices.
+While overall stability has improved, unexpected behavior may still
+occur on some devices.
@@ -205 +197,2 @@ While overall stability has improved, unexpected behavior may still occur on som
-### Known issues
+Also, this fork is maintained by someone who doesn't understand half 
+the changes they make so keep your expectations low and maybe you'll be pleasantly surprised.
@@ -207,4 +200,2 @@ While overall stability has improved, unexpected behavior may still occur on som
-- Random crashes under certain conditions
-- Granting notification permission at launch may cause the LED toggle switch to appear disabled even though animations continue running
-- On the Retroid Pocket Mini, only the left stick turns on in Ambilight mode.  
-  This issue can be solved using the **custom color sampler mode**.
+Also also, the maintainer of this fork only cares about their own AYN Thor
+so if you're not using that specific device or something similar you're probably better off using the original version.
@@ -212 +203 @@ While overall stability has improved, unexpected behavior may still occur on som
-Thanks to **r/hupo224** for helping investigate this issue.
+### **Known issues**
@@ -214,5 +205,6 @@ Thanks to **r/hupo224** for helping investigate this issue.
----
-
-# ❤️ Contributors
-
-Huge thanks to **KuriGohan-Kamehameha** for the **massive work and new features added to the project**, including major functionality improvements and system integrations.
+- Random crashes under certain conditions
+- Granting notification permission at launch may cause the LED toggle
+  switch to appear disabled even though animations continue running
+- On the Retroid Pocket Mini, only the left stick turns on in Ambilight mode.
+  This issue can be solved using the custom color sampler mode.
+  (Thanks to r/hupo224 for helping with this issue.)
@@ -220,2 +212 @@ Huge thanks to **KuriGohan-Kamehameha** for the **massive work and new features
-Project:  
-https://github.com/KuriGohan-Kamehameha
+If you encounter issues, please open a GitHub issue or check the existing ones.
@@ -223 +214 @@ https://github.com/KuriGohan-Kamehameha
----
+## 🧬 Fork vs Upstream (what’s different?)
@@ -225 +216 @@ https://github.com/KuriGohan-Kamehameha
-# ☕ Support the Project
+This fork contains enhancements that aren’t (yet) in the upstream Pollux-MoonBench/Bifrost main branch.
@@ -227 +218 @@ https://github.com/KuriGohan-Kamehameha
-If you enjoy Bifrost and want to support development, you can **buy me a coffee** here:
+### Key additions
@@ -229 +220,8 @@ If you enjoy Bifrost and want to support development, you can **buy me a coffee*
-👉 https://ko-fi.com/pollux_moonbench
+- **Auto-start on boot** to keep Bifrost running after device reboot.
+- Individual left/right control -- make each side a distinct colour!
+- Profiles can now be assigned to apps, and will automatically activate when the selected app is in the foreground. 
+- **Improved charging indicator**:
+  - Breathing lights while charging
+  - Charging speed indication
+  - Flash notification when charging completes
+- **New CPU temperature LED animation** (colors shift based on thermal readings).
@@ -231 +229 @@ If you enjoy Bifrost and want to support development, you can **buy me a coffee*
-Thank you! ❤️
+### Project-level differences
@@ -233 +231,3 @@ Thank you! ❤️
----
+- Includes a **`CHANGELOG.md`** to track releases and notable changes.
+- Releases include a published **APK asset** (tagged `v1.0.6`).
+- Updated UI layout and animation smoothing tweaks across several animations.
@@ -235 +235 @@ Thank you! ❤️
-# 📜 License
+## 📜 License
@@ -239,3 +239,4 @@ This project is licensed under **GPLv3**.
-You are free to use, study, modify, and redistribute the app under the terms of the GPLv3 license.
-
-This app is provided for free in this repository and **cannot be sold to you.**
+You are free to use, study, modify, and redistribute the app under the
+terms of the GPLv3 license.\
+This app is provided for free in this repository and **cannot be sold to
+you.** You should never have to pay for Bifrost!
diff --git a/app/src/main/java/com/moonbench/bifrost/BackupArchiveTransfer.kt b/app/src/main/java/com/moonbench/bifrost/BackupArchiveTransfer.kt
new file mode 100644
index 0000000..6d0b4d2
--- /dev/null
+++ b/app/src/main/java/com/moonbench/bifrost/BackupArchiveTransfer.kt
@@ -0,0 +1,436 @@
+package com.moonbench.bifrost
+
+import android.content.Context
+import android.content.SharedPreferences
+import android.net.Uri
+import android.os.CancellationSignal
+import org.json.JSONArray
+import org.json.JSONObject
+import java.io.ByteArrayOutputStream
+import java.util.zip.ZipEntry
+import java.util.zip.ZipInputStream
+import java.util.zip.ZipOutputStream
+
+object BackupArchiveTransfer {
+
+    private const val BACKUP_SCHEMA = "bifrost_full_backup"
+    private const val BACKUP_VERSION = 1
+    private const val PREF_FILE_NAME = "bifrost_prefs"
+    private const val MANIFEST_ENTRY_NAME = "manifest.json"
+    private const val PREFS_ENTRY_NAME = "prefs.json"
+    private const val ICONS_DIR_PREFIX = "icons/"
+    private val THEME_PREF_KEYS = setOf(
+        "selected_ui_theme",
+        "colored_logo_enabled"
+    )
+    private val PROFILE_PREF_KEYS = setOf(
+        "presets_json",
+        "last_preset_name",
+        "app_profile_mappings",
+        "auto_switch_enabled",
+        "pending_projection_package",
+        "pending_projection_preset",
+        "pending_projection_notified"
+    )
+
+    data class CategoryOptions(
+        val themes: Boolean = true,
+        val profiles: Boolean = true,
+        val images: Boolean = true
+    ) {
+        fun hasAtLeastOneCategory(): Boolean = themes || profiles || images
+    }
+
+    data class ExportResult(
+        val preferenceCount: Int,
+        val iconCount: Int,
+        val appliedOptions: CategoryOptions,
+        val warnings: List<String>
+    )
+
+    data class ImportResult(
+        val preferenceCount: Int,
+        val iconCount: Int,
+        val appliedOptions: CategoryOptions,
+        val warnings: List<String>,
+        val errors: List<String>
+    )
+
+    fun exportToUri(
+        context: Context,
+        uri: Uri,
+        options: CategoryOptions = CategoryOptions(),
+        cancelSignal: CancellationSignal? = null
+    ): ExportResult {
+        if (!options.hasAtLeastOneCategory()) {
+            return ExportResult(
+                preferenceCount = 0,
+                iconCount = 0,
+                appliedOptions = options,
+                warnings = listOf("No categories were selected for backup.")
+            )
+        }
+
+        val prefs = context.getSharedPreferences(PREF_FILE_NAME, Context.MODE_PRIVATE)
+        val warnings = mutableListOf<String>()
+        val prefsJson = serializePreferences(prefs, options)
+        val iconNames = if (options.images) {
+            PresetImageStorage.listStoredIconFileNames(context)
+        } else {
+            emptyList()
+        }
+        var exportedIconCount = 0
+
+        val manifest = JSONObject().apply {
+            put("schema", BACKUP_SCHEMA)
+            put("version", BACKUP_VERSION)
+            put("prefsFile", PREF_FILE_NAME)
+            put("iconDirectory", "preset_icons")
+            put("categories", JSONObject().apply {
+                put("themes", options.themes)
+                put("profiles", options.profiles)
+                put("images", options.images)
+            })
+        }
+
+        cancelSignal?.throwIfCanceled()
+        context.contentResolver.openOutputStream(uri)?.use { stream ->
+            ZipOutputStream(stream.buffered()).use { zip ->
+                cancelSignal?.throwIfCanceled()
+                zip.putNextEntry(ZipEntry(MANIFEST_ENTRY_NAME))
+                zip.write(manifest.toString(2).toByteArray(Charsets.UTF_8))
+                zip.closeEntry()
+
+                cancelSignal?.throwIfCanceled()
+                zip.putNextEntry(ZipEntry(PREFS_ENTRY_NAME))
+                zip.write(prefsJson.toString(2).toByteArray(Charsets.UTF_8))
+                zip.closeEntry()
+
+                iconNames.forEach { iconName ->
+                    cancelSignal?.throwIfCanceled()
+                    val input = PresetImageStorage.openIconInputStream(context, iconName)
+                    if (input == null) {
+                        warnings += "Image not found for '$iconName'; skipping."
+                        return@forEach
+                    }
+
+                    input.use { iconStream ->
+                        cancelSignal?.throwIfCanceled()
+                        zip.putNextEntry(ZipEntry("$ICONS_DIR_PREFIX$iconName"))
+                        iconStream.copyTo(zip)
+                        zip.closeEntry()
+                        exportedIconCount++
+                    }
+                }
+            }
+        } ?: return ExportResult(
+            preferenceCount = 0,
+            iconCount = 0,
+            appliedOptions = options,
+            warnings = listOf("Unable to write selected file.")
+        )
+
+        return ExportResult(
+            preferenceCount = prefs.all.size,
+            iconCount = exportedIconCount,
+            appliedOptions = options,
+            warnings = warnings
+        )
+    }
+
+    fun importFromUri(
+        context: Context,
+        uri: Uri,
+        options: CategoryOptions = CategoryOptions(),
+        cancelSignal: CancellationSignal? = null
+    ): ImportResult {
+        if (!options.hasAtLeastOneCategory()) {
+            return ImportResult(
+                preferenceCount = 0,
+                iconCount = 0,
+                appliedOptions = options,
+                warnings = emptyList(),
+                errors = listOf("No categories were selected for restore.")
+            )
+        }
+
+        val warnings = mutableListOf<String>()
+        val errors = mutableListOf<String>()
+
+        val zipEntries = mutableMapOf<String, ByteArray>()
+        cancelSignal?.throwIfCanceled()
+        context.contentResolver.openInputStream(uri)?.use { input ->
+            ZipInputStream(input.buffered()).use { zip ->
+                while (true) {
+                    cancelSignal?.throwIfCanceled()
+                    val entry = zip.nextEntry ?: break
+                    if (entry.isDirectory) {
+                        zip.closeEntry()
+                        continue
+                    }
+
+                    val data = ByteArrayOutputStream().use { output ->
+                        zip.copyTo(output)
+                        output.toByteArray()
+                    }
+                    zipEntries[entry.name] = data
+                    zip.closeEntry()
+                }
+            }
+        } ?: return ImportResult(
+            preferenceCount = 0,
+            iconCount = 0,
+            appliedOptions = options,
+            warnings = emptyList(),
+            errors = listOf("Unable to read selected file.")
+        )
+
+        val manifestRaw = zipEntries[MANIFEST_ENTRY_NAME]
+            ?: return ImportResult(
+                preferenceCount = 0,
+                iconCount = 0,
+                appliedOptions = options,
+                warnings = emptyList(),
+                errors = listOf("Archive is missing manifest.json")
+            )
+
+        val manifest = runCatching {
+            JSONObject(manifestRaw.toString(Charsets.UTF_8))
+        }.getOrElse {
+            return ImportResult(
+                preferenceCount = 0,
+                iconCount = 0,
+                appliedOptions = options,
+                warnings = emptyList(),
+                errors = listOf("manifest.json is invalid JSON")
+            )
+        }
+
+        if (manifest.optString("schema") != BACKUP_SCHEMA) {
+            errors += "Unknown backup schema."
+            return ImportResult(
+                preferenceCount = 0,
+                iconCount = 0,
+                appliedOptions = options,
+                warnings = warnings,
+                errors = errors
+            )
+        }
+
+        val version = manifest.optInt("version", -1)
+        if (version < 1) {
+            errors += "Unsupported backup version: $version"
+            return ImportResult(
+                preferenceCount = 0,
+                iconCount = 0,
+                appliedOptions = options,
+                warnings = warnings,
+                errors = errors
+            )
+        } else if (version > BACKUP_VERSION) {
+            warnings += "Backup version $version is newer than supported version $BACKUP_VERSION. Attempting compatible restore."
+        }
+
+        val prefsRaw = zipEntries[PREFS_ENTRY_NAME]
+            ?: return ImportResult(
+                preferenceCount = 0,
+                iconCount = 0,
+                appliedOptions = options,
+                warnings = warnings,
+                errors = listOf("Archive is missing prefs.json")
+            )
+
+        val prefsJson = runCatching {
+            JSONObject(prefsRaw.toString(Charsets.UTF_8))
+        }.getOrElse {
+            return ImportResult(
+                preferenceCount = 0,
+                iconCount = 0,
+                appliedOptions = options,
+                warnings = warnings,
+                errors = listOf("prefs.json is invalid JSON")
+            )
+        }
+
+        val effectiveOptions = resolveEffectiveOptions(manifest, options)
+
+        val prefItems = prefsJson.optJSONArray("items") ?: JSONArray()
+        val prefs = context.getSharedPreferences(PREF_FILE_NAME, Context.MODE_PRIVATE)
+        val editor = prefs.edit()
+
+        if (effectiveOptions.themes) {
+            THEME_PREF_KEYS.forEach { editor.remove(it) }
+        }
+        if (effectiveOptions.profiles) {
+            PROFILE_PREF_KEYS.forEach { editor.remove(it) }
+        }
+
+        var importedPrefCount = 0
+        for (index in 0 until prefItems.length()) {
+            cancelSignal?.throwIfCanceled()
+            val item = prefItems.optJSONObject(index) ?: continue
+            val key = item.optString("key").takeIf { it.isNotBlank() } ?: continue
+            if (!shouldIncludePreference(key, effectiveOptions)) continue
+            val type = item.optString("type")
+
+            when (type) {
+                "boolean" -> {
+                    editor.putBoolean(key, item.optBoolean("value", false))
+                    importedPrefCount++
+                }
+
+                "int" -> {
+                    editor.putInt(key, item.optInt("value", 0))
+                    importedPrefCount++
+                }
+
+                "long" -> {
+                    val value = item.optLong("value", 0L)
+                    editor.putLong(key, value)
+                    importedPrefCount++
+                }
+
+                "float" -> {
+                    val value = item.optDouble("value", 0.0).toFloat()
+                    editor.putFloat(key, value)
+                    importedPrefCount++
+                }
+
+                "string" -> {
+                    editor.putString(key, item.optString("value"))
+                    importedPrefCount++
+                }
+
+                "string_set" -> {
+                    val valueArray = item.optJSONArray("value") ?: JSONArray()
+                    val valueSet = linkedSetOf<String>()
+                    for (setIndex in 0 until valueArray.length()) {
+                        val value = valueArray.optString(setIndex)
+                        if (value.isNotEmpty()) valueSet += value
+                    }
+                    editor.putStringSet(key, valueSet)
+                    importedPrefCount++
+                }
+
+                else -> warnings += "Preference '$key' uses unsupported type '$type'; skipping."
+            }
+        }
+
+        if (!editor.commit()) {
+            return ImportResult(
+                preferenceCount = 0,
+                iconCount = 0,
+                appliedOptions = effectiveOptions,
+                warnings = warnings,
+                errors = listOf("Failed to commit restored preferences")
+            )
+        }
+
+        var importedIconCount = 0
+        if (effectiveOptions.images) {
+            PresetImageStorage.clearAllIcons(context)
+            zipEntries.forEach { (entryName, bytes) ->
+                cancelSignal?.throwIfCanceled()
+                if (!entryName.startsWith(ICONS_DIR_PREFIX)) return@forEach
+
+                val fileName = entryName.removePrefix(ICONS_DIR_PREFIX).trim()
+                if (fileName.isBlank()) return@forEach
+
+                if (PresetImageStorage.writeIconWithExactName(context, fileName, bytes)) {
+                    importedIconCount++
+                } else {
+                    warnings += "Could not restore image '$fileName'."
+                }
+            }
+        }
+
+        if (effectiveOptions.profiles && !effectiveOptions.images) {
+            warnings += "Profiles restored without images; presets that reference uploaded images may show missing artwork."
+        }
+
+        return ImportResult(
+            preferenceCount = importedPrefCount,
+            iconCount = importedIconCount,
+            appliedOptions = effectiveOptions,
+            warnings = warnings,
+            errors = errors
+        )
+    }
+
+    private fun serializePreferences(prefs: SharedPreferences, options: CategoryOptions): JSONObject {
+        val items = JSONArray()
+
+        prefs.all.toSortedMap().forEach { (key, value) ->
+            if (!shouldIncludePreference(key, options)) {
+                return@forEach
+            }
+
+            val item = JSONObject().apply { put("key", key) }
+            when (value) {
+                is Boolean -> {
+                    item.put("type", "boolean")
+                    item.put("value", value)
+                }
+
+                is Int -> {
+                    item.put("type", "int")
+                    item.put("value", value)
+                }
+
+                is Long -> {
+                    item.put("type", "long")
+                    item.put("value", value)
+                }
+
+                is Float -> {
+                    item.put("type", "float")
+                    item.put("value", value.toDouble())
+                }
+
+                is String -> {
+                    item.put("type", "string")
+                    item.put("value", value)
+                }
+
+                is Set<*> -> {
+                    val setValues = value
+                        .filterIsInstance<String>()
+                        .sorted()
+                    item.put("type", "string_set")
+                    item.put("value", JSONArray(setValues))
+                }
+
+                else -> {
+                    // Ignore unsupported preference types
+                    return@forEach
+                }
+            }
+            items.put(item)
+        }
+
+        return JSONObject().apply {
+            put("items", items)
+        }
+    }
+
+    private fun shouldIncludePreference(key: String, options: CategoryOptions): Boolean {
+        return (options.themes && key in THEME_PREF_KEYS) ||
+            (options.profiles && key in PROFILE_PREF_KEYS)
+    }
+
+    private fun resolveEffectiveOptions(
+        manifest: JSONObject,
+        requested: CategoryOptions
+    ): CategoryOptions {
+        val categories = manifest.optJSONObject("categories")
+        if (categories == null) {
+            return requested
+        }
+
+        return CategoryOptions(
+            themes = requested.themes && categories.optBoolean("themes", true),
+            profiles = requested.profiles && categories.optBoolean("profiles", true),
+            images = requested.images && categories.optBoolean("images", true)
+        )
+    }
+}
diff --git a/app/src/main/java/com/moonbench/bifrost/MainActivity.kt b/app/src/main/java/com/moonbench/bifrost/MainActivity.kt
index b9127e5..0f2f3b2 100644
--- a/app/src/main/java/com/moonbench/bifrost/MainActivity.kt
+++ b/app/src/main/java/com/moonbench/bifrost/MainActivity.kt
@@ -7,0 +8 @@ import android.app.ActivityOptions
+import android.content.res.ColorStateList
@@ -86,0 +88 @@ class MainActivity : AppCompatActivity() {
+    private lateinit var adaptiveBrightnessSwitch: SwitchMaterial
@@ -90,0 +93,3 @@ class MainActivity : AppCompatActivity() {
+    private lateinit var themeSpinner: Spinner
+    private lateinit var exportThemeButton: MaterialButton
+    private lateinit var importThemeButton: MaterialButton
@@ -117,0 +123 @@ class MainActivity : AppCompatActivity() {
+    private lateinit var coloredLogoSwitch: SwitchMaterial
@@ -123,0 +130,3 @@ class MainActivity : AppCompatActivity() {
+    private lateinit var tabUiSettings: MaterialButton
+    private lateinit var tabBehaviorSettings: MaterialButton
+    private lateinit var tabThemesSettings: MaterialButton
@@ -131,0 +141 @@ class MainActivity : AppCompatActivity() {
+    private lateinit var appProfileCard: MaterialCardView
@@ -134,0 +145,2 @@ class MainActivity : AppCompatActivity() {
+    private lateinit var themesCard: MaterialCardView
+    private lateinit var settingsSystemStatusCard: MaterialCardView
@@ -142,0 +155,35 @@ class MainActivity : AppCompatActivity() {
+    private enum class SettingsTab {
+        UI,
+        BEHAVIOR,
+        THEMES
+    }
+
+    private data class HeaderThemePalette(
+        val introHueStart: Float,
+        val introHueSpan: Float,
+        val introSaturation: Float,
+        val introValue: Float,
+        val settleHueStart: Float,
+        val settleHueSpan: Float,
+        val settleHueWobbleAmplitude: Float,
+        val settleSaturationBase: Float,
+        val settleSaturationWave: Float,
+        val settleValueBase: Float,
+        val settleValueWave: Float,
+        val settleAlphaBase: Int,
+        val settleAlphaWave: Int,
+        val settlePhaseDegrees: Float
+    )
+
+    private data class UiTheme(
+        val id: String,
+        val label: String,
+        val backgroundColor: Int,
+        val cardColor: Int,
+        val surfaceColor: Int,
+        val textColor: Int,
+        val accentColor: Int,
+        val accentLightColor: Int,
+        val headerPalette: HeaderThemePalette
+    )
+
@@ -167,0 +215,3 @@ class MainActivity : AppCompatActivity() {
+        private const val PREF_ADAPTIVE_BRIGHTNESS = "adaptive_brightness_enabled"
+        private const val PREF_SELECTED_UI_THEME = "selected_ui_theme"
+        private const val PREF_COLORED_LOGO_ENABLED = "colored_logo_enabled"
@@ -209,0 +260 @@ class MainActivity : AppCompatActivity() {
+    private var selectedAdaptiveBrightness: Boolean = false
@@ -224,0 +276,2 @@ class MainActivity : AppCompatActivity() {
+    private var currentSettingsTab: SettingsTab = SettingsTab.UI
+    private var isColoredLogoEnabled: Boolean = true
@@ -230,0 +284,2 @@ class MainActivity : AppCompatActivity() {
+    private var pendingBackupExportOptions: BackupArchiveTransfer.CategoryOptions? = null
+    private var pendingBackupImportOptions: BackupArchiveTransfer.CategoryOptions? = null
@@ -237,0 +293,55 @@ class MainActivity : AppCompatActivity() {
+    private val builtInThemes = listOf(
+        UiTheme(
+            id = "classic",
+            label = "Classic",
+            backgroundColor = Color.parseColor("#0A0E1A"),
+            cardColor = Color.parseColor("#12182B"),
+            surfaceColor = Color.parseColor("#1A2236"),
+            textColor = Color.parseColor("#E8EEFF"),
+            accentColor = Color.parseColor("#6366F1"),
+            accentLightColor = Color.parseColor("#818CF8"),
+            headerPalette = HeaderThemePalette(
+                introHueStart = 0f,
+                introHueSpan = 360f,
+                introSaturation = 0.82f,
+                introValue = 1f,
+                settleHueStart = 18f,
+                settleHueSpan = 300f,
+                settleHueWobbleAmplitude = 10f,
+                settleSaturationBase = 0.28f,
+                settleSaturationWave = 0.14f,
+                settleValueBase = 0.92f,
+                settleValueWave = 0.08f,
+                settleAlphaBase = 224,
+                settleAlphaWave = 31,
+                settlePhaseDegrees = 18f
+            )
+        ),
+        UiTheme(
+            id = "oled_purple",
+            label = "OLED Purple",
+            backgroundColor = Color.parseColor("#000000"),
+            cardColor = Color.parseColor("#000000"),
+            surfaceColor = Color.parseColor("#000000"),
+            textColor = Color.parseColor("#C084FC"),
+            accentColor = Color.parseColor("#A855F7"),
+            accentLightColor = Color.parseColor("#C084FC"),
+            headerPalette = HeaderThemePalette(
+                introHueStart = 264f,
+                introHueSpan = 64f,
+                introSaturation = 0.9f,
+                introValue = 0.98f,
+                settleHueStart = 272f,
+                settleHueSpan = 48f,
+                settleHueWobbleAmplitude = 5f,
+                settleSaturationBase = 0.5f,
+                settleSaturationWave = 0.16f,
+                settleValueBase = 0.76f,
+                settleValueWave = 0.2f,
+                settleAlphaBase = 236,
+                settleAlphaWave = 19,
+                settlePhaseDegrees = 12f
+            )
+        )
+    )
+    private var selectedUiTheme: UiTheme = builtInThemes.first()
@@ -348 +458,9 @@ class MainActivity : AppCompatActivity() {
-            exportPresetBundle(uri)
+            val options = pendingBackupExportOptions ?: BackupArchiveTransfer.CategoryOptions()
+            pendingBackupExportOptions = null
+            exportPresetBundle(uri, options)
+        }
+
+    private val exportThemeLauncher =
+        registerForActivityResult(ActivityResultContracts.CreateDocument("application/json")) { uri: Uri? ->
+            if (uri == null) return@registerForActivityResult
+            exportThemeBundle(uri)
@@ -354 +472,9 @@ class MainActivity : AppCompatActivity() {
-            importPresetBundle(uri)
+            val options = pendingBackupImportOptions ?: BackupArchiveTransfer.CategoryOptions()
+            pendingBackupImportOptions = null
+            importPresetBundle(uri, options)
+        }
+
+    private val importThemeLauncher =
+        registerForActivityResult(ActivityResultContracts.OpenDocument()) { uri: Uri? ->
+            if (uri == null) return@registerForActivityResult
+            importThemeBundle(uri)
@@ -408,0 +535,3 @@ class MainActivity : AppCompatActivity() {
+        tabUiSettings = findViewById(R.id.tabUiSettings)
+        tabBehaviorSettings = findViewById(R.id.tabBehaviorSettings)
+        tabThemesSettings = findViewById(R.id.tabThemesSettings)
@@ -420,0 +550 @@ class MainActivity : AppCompatActivity() {
+        adaptiveBrightnessSwitch = findViewById(R.id.adaptiveBrightnessSwitch)
@@ -423,0 +554,3 @@ class MainActivity : AppCompatActivity() {
+        themeSpinner = findViewById(R.id.themeSpinner)
+        exportThemeButton = findViewById(R.id.exportThemeButton)
+        importThemeButton = findViewById(R.id.importThemeButton)
@@ -448,0 +582 @@ class MainActivity : AppCompatActivity() {
+        coloredLogoSwitch = findViewById(R.id.coloredLogoSwitch)
@@ -459,0 +594 @@ class MainActivity : AppCompatActivity() {
+        appProfileCard = findViewById(R.id.appProfileCard)
@@ -462,0 +598,2 @@ class MainActivity : AppCompatActivity() {
+        themesCard = findViewById(R.id.themesCard)
+        settingsSystemStatusCard = findViewById(R.id.settingsSystemStatusCard)
@@ -465,0 +603 @@ class MainActivity : AppCompatActivity() {
+        bifrostTitleLabel = bifrostTitleText.text.toString()
@@ -497,0 +636 @@ class MainActivity : AppCompatActivity() {
+        setupAdaptiveBrightnessSwitch()
@@ -498,0 +638,4 @@ class MainActivity : AppCompatActivity() {
+        setupSettingsTabs()
+        setupThemeFeature()
+        setupColoredLogoSwitch()
+        setupRainbowTitleText()
@@ -580,0 +724,168 @@ class MainActivity : AppCompatActivity() {
+    private fun setupSettingsTabs() {
+        tabUiSettings.setOnClickListener { setSettingsTab(SettingsTab.UI) }
+        tabBehaviorSettings.setOnClickListener { setSettingsTab(SettingsTab.BEHAVIOR) }
+        tabThemesSettings.setOnClickListener { setSettingsTab(SettingsTab.THEMES) }
+        setSettingsTab(currentSettingsTab)
+    }
+
+    private fun setSettingsTab(tab: SettingsTab) {
+        currentSettingsTab = tab
+        val showingUi = tab == SettingsTab.UI
+        val showingBehavior = tab == SettingsTab.BEHAVIOR
+        val showingThemes = tab == SettingsTab.THEMES
+
+        modeCard.visibility = if (showingUi) View.VISIBLE else View.GONE
+        colorCard.visibility = if (showingUi) View.VISIBLE else View.GONE
+        animationCard.visibility = if (showingUi) View.VISIBLE else View.GONE
+        performanceCard.visibility = if (showingUi) View.VISIBLE else View.GONE
+
+        settingsSystemStatusCard.visibility = if (showingBehavior) View.VISIBLE else View.GONE
+        appProfileCard.visibility = if (showingBehavior) View.VISIBLE else View.GONE
+
+        val thorCard = findViewById<View>(R.id.thorSettingsCard)
+        thorCard?.visibility = if (showingBehavior && DeviceInfo.isAynThor) View.VISIBLE else View.GONE
+
+        themesCard.visibility = if (showingThemes) View.VISIBLE else View.GONE
+
+        updateSettingsTabButtonStyles()
+    }
+
+    private fun updateSettingsTabButtonStyles() {
+        updateSettingsTabButtonState(tabUiSettings, currentSettingsTab == SettingsTab.UI)
+        updateSettingsTabButtonState(tabBehaviorSettings, currentSettingsTab == SettingsTab.BEHAVIOR)
+        updateSettingsTabButtonState(tabThemesSettings, currentSettingsTab == SettingsTab.THEMES)
+    }
+
+    private fun updateSettingsTabButtonState(button: MaterialButton, selected: Boolean) {
+        val selectedTint = ColorStateList.valueOf(selectedUiTheme.accentColor)
+        val unselectedTint = ColorStateList.valueOf(selectedUiTheme.surfaceColor)
+        button.backgroundTintList = if (selected) selectedTint else unselectedTint
+        button.setTextColor(if (selected) Color.WHITE else selectedUiTheme.textColor)
+        button.strokeColor = ColorStateList.valueOf(selectedUiTheme.accentLightColor)
+    }
+
+    private fun setupThemeFeature() {
+        val adapter = ArrayAdapter(this, R.layout.item_spinner_bifrost, builtInThemes.map { it.label })
+        adapter.setDropDownViewResource(R.layout.item_spinner_dropdown_bifrost)
+        themeSpinner.adapter = adapter
+
+        val selectedThemeId = prefs.getString(PREF_SELECTED_UI_THEME, builtInThemes.first().id)
+        val selectedIndex = builtInThemes.indexOfFirst { it.id == selectedThemeId }.takeIf { it >= 0 } ?: 0
+        selectedUiTheme = builtInThemes[selectedIndex]
+        themeSpinner.setSelection(selectedIndex, false)
+        applySelectedTheme(selectedUiTheme, persistSelection = false)
+
+        themeSpinner.onItemSelectedListener = object : AdapterView.OnItemSelectedListener {
+            override fun onItemSelected(parent: AdapterView<*>?, view: View?, position: Int, id: Long) {
+                val theme = builtInThemes.getOrNull(position) ?: return
+                applySelectedTheme(theme, persistSelection = true)
+            }
+
+            override fun onNothingSelected(parent: AdapterView<*>?) {}
+        }
+    }
+
+    private fun applySelectedTheme(theme: UiTheme, persistSelection: Boolean) {
+        selectedUiTheme = theme
+        if (persistSelection) {
+            prefs.edit().putString(PREF_SELECTED_UI_THEME, theme.id).apply()
+        }
+        applyUiTheme(theme)
+    }
+
+    private fun applyUiTheme(theme: UiTheme) {
+        setupStatusBar()
+        findViewById<View>(android.R.id.content)?.setBackgroundColor(theme.backgroundColor)
+        homeContainer.setBackgroundColor(theme.backgroundColor)
+        settingsOverlay.setBackgroundColor(theme.backgroundColor)
+        applyThemeToViewTree(homeContainer, theme)
+        applyThemeToViewTree(settingsOverlay, theme)
+        applyHeaderLogoPreference()
+        updateSettingsTabButtonStyles()
+    }
+
+    private fun applyThemeToViewTree(view: View, theme: UiTheme) {
+        when (view) {
+            is MaterialCardView -> {
+                view.setCardBackgroundColor(theme.cardColor)
+                view.strokeColor = theme.accentColor
+            }
+
+            is MaterialButton -> {
+                view.backgroundTintList = ColorStateList.valueOf(theme.surfaceColor)
+                view.setTextColor(theme.textColor)
+                view.iconTint = ColorStateList.valueOf(theme.textColor)
+                view.strokeColor = ColorStateList.valueOf(theme.accentColor)
+            }
+        }
+
+        if (view is ViewGroup) {
+            for (index in 0 until view.childCount) {
+                applyThemeToViewTree(view.getChildAt(index), theme)
+            }
+        }
+    }
+
+    private fun setupColoredLogoSwitch() {
+        isColoredLogoEnabled = prefs.getBoolean(PREF_COLORED_LOGO_ENABLED, true)
+        coloredLogoSwitch.isChecked = isColoredLogoEnabled
+        applyHeaderLogoPreference()
+
+        coloredLogoSwitch.setOnCheckedChangeListener { _, isChecked ->
+            isColoredLogoEnabled = isChecked
+            prefs.edit().putBoolean(PREF_COLORED_LOGO_ENABLED, isChecked).apply()
+            applyHeaderLogoPreference()
+            if (isChecked) {
+                playBifrostHeaderAnimation()
+            }
+        }
+    }
+
+    private fun setupRainbowTitleText() {
+        if (bifrostTitleLabel.isBlank()) return
+
+        bifrostLogoView.setOnClickListener {
+            if (isColoredLogoEnabled) {
+                playBifrostHeaderAnimation()
+            }
+        }
+        bifrostTitleText.setOnClickListener {
+            if (isColoredLogoEnabled) {
+                playBifrostHeaderAnimation()
+            }
+        }
+
+        if (isColoredLogoEnabled) {
+            playBifrostHeaderAnimation()
+        } else {
+            applyHeaderLogoPreference()
+        }
+    }
+
+    private fun applyHeaderLogoPreference() {
+        if (bifrostTitleLabel.isBlank()) return
+
+        titleIntroAnimator?.cancel()
+        headerSettleAnimator?.cancel()
+        titleIntroAnimator = null
+        headerSettleAnimator = null
+
+        bifrostLogoView.rotation = 0f
+        bifrostLogoView.scaleX = 1f
+        bifrostLogoView.scaleY = 1f
+        bifrostLogoView.translationY = 0f
+        bifrostLogoView.alpha = 1f
+
+        if (isColoredLogoEnabled) {
+            applyWatercolorTitlePhase(
+                bifrostTitleLabel,
+                selectedUiTheme.headerPalette.settlePhaseDegrees
+            )
+            bifrostLogoView.clearColorFilter()
+        } else {
+            bifrostTitleText.text = bifrostTitleLabel
+            bifrostTitleText.setTextColor(selectedUiTheme.textColor)
+            bifrostLogoView.clearColorFilter()
+        }
+    }
+
@@ -1646 +1957 @@ class MainActivity : AppCompatActivity() {
-        window.statusBarColor = getColor(R.color.bifrost_bg)
+        window.statusBarColor = selectedUiTheme.backgroundColor
@@ -1715,0 +2027,38 @@ class MainActivity : AppCompatActivity() {
+    private fun normalizedCyclePhase(phaseDegrees: Float): Float {
+        return ((phaseDegrees % 360f) + 360f) % 360f / 360f
+    }
+
+    private fun computeIntroThemeColor(index: Int, maxIndex: Int, phaseDegrees: Float): Int {
+        val palette = selectedUiTheme.headerPalette
+        val phase = normalizedCyclePhase(phaseDegrees)
+        val letterProgress = index / maxIndex.toFloat()
+        val hueWindow = palette.introHueSpan * ((phase + letterProgress) % 1f)
+        val hue = (palette.introHueStart + hueWindow) % 360f
+        return Color.HSVToColor(floatArrayOf(hue, palette.introSaturation, palette.introValue))
+    }
+
+    private fun computeSettleThemeColor(index: Int, maxIndex: Int, phaseDegrees: Float): Int {
+        val palette = selectedUiTheme.headerPalette
+        val phase = normalizedCyclePhase(phaseDegrees)
+        val letterProgress = index / maxIndex.toFloat()
+        val hueProgress = (letterProgress + phase) % 1f
+        val hue = (
+            palette.settleHueStart +
+                palette.settleHueSpan * hueProgress +
+                palette.settleHueWobbleAmplitude * sin(letterProgress * PI).toFloat()
+            ) % 360f
+        val saturation = (
+            palette.settleSaturationBase +
+                palette.settleSaturationWave * ((sin(letterProgress * PI * 3.0) + 1.0) / 2.0).toFloat()
+            ).coerceIn(0f, 1f)
+        val value = (
+            palette.settleValueBase +
+                palette.settleValueWave * ((cos(letterProgress * PI * 2.0) + 1.0) / 2.0).toFloat()
+            ).coerceIn(0f, 1f)
+        val alpha = (
+            palette.settleAlphaBase +
+                palette.settleAlphaWave * ((sin(letterProgress * PI * 2.5) + 1.0) / 2.0)
+            ).roundToInt().coerceIn(0, 255)
+        return Color.HSVToColor(alpha, floatArrayOf(hue, saturation, value))
+    }
+
@@ -1716,0 +2066,6 @@ class MainActivity : AppCompatActivity() {
+        if (!isColoredLogoEnabled) {
+            bifrostTitleText.text = text
+            bifrostTitleText.setTextColor(selectedUiTheme.textColor)
+            return
+        }
+
@@ -1723,2 +2078 @@ class MainActivity : AppCompatActivity() {
-            val hue = (phaseDegrees + (360f * index / maxIndex)) % 360f
-            val color = Color.HSVToColor(floatArrayOf(hue, 0.82f, 1f))
+            val color = computeIntroThemeColor(index, maxIndex, phaseDegrees)
@@ -1735,0 +2090,19 @@ class MainActivity : AppCompatActivity() {
+    private fun applyWatercolorTitlePhase(text: String, phaseDegrees: Float) {
+        val watercolorText = SpannableString(text)
+        val maxIndex = (text.length - 1).coerceAtLeast(1)
+
+        text.indices.forEach { index ->
+            if (text[index].isWhitespace()) return@forEach
+
+            val color = computeSettleThemeColor(index, maxIndex, phaseDegrees)
+            watercolorText.setSpan(
+                ForegroundColorSpan(color),
+                index,
+                index + 1,
+                Spanned.SPAN_EXCLUSIVE_EXCLUSIVE
+            )
+        }
+
+        bifrostTitleText.text = watercolorText
+    }
+
@@ -1737,0 +2111,4 @@ class MainActivity : AppCompatActivity() {
+        if (!isColoredLogoEnabled) {
+            applyHeaderLogoPreference()
+            return
+        }
@@ -1785,2 +2162,10 @@ class MainActivity : AppCompatActivity() {
-        bifrostTitleText.text = bifrostTitleLabel
-        bifrostTitleText.setTextColor(ContextCompat.getColor(this, R.color.bifrost_text))
+        if (isColoredLogoEnabled) {
+            applyWatercolorTitlePhase(
+                bifrostTitleLabel,
+                selectedUiTheme.headerPalette.settlePhaseDegrees
+            )
+        } else {
+            bifrostTitleText.text = bifrostTitleLabel
+            bifrostTitleText.setTextColor(selectedUiTheme.textColor)
+        }
+
@@ -1810 +2195 @@ class MainActivity : AppCompatActivity() {
-                resetBifrostHeaderAnimationState()
+                applyHeaderLogoPreference()
@@ -2053,4 +2437,0 @@ class MainActivity : AppCompatActivity() {
-                    selectedSmoothness = selectedSpeed
-                    if (fromUser) {
-                        smoothnessSeekBar.progress = progress
-                    }
@@ -2074,4 +2454,0 @@ class MainActivity : AppCompatActivity() {
-                    selectedSpeed = selectedSmoothness
-                    if (fromUser) {
-                        speedSeekBar.progress = progress
-                    }
@@ -2222,0 +2600,14 @@ class MainActivity : AppCompatActivity() {
+    private fun setupAdaptiveBrightnessSwitch() {
+        selectedAdaptiveBrightness = prefs.getBoolean(PREF_ADAPTIVE_BRIGHTNESS, false)
+        adaptiveBrightnessSwitch.isChecked = selectedAdaptiveBrightness
+
+        adaptiveBrightnessSwitch.setOnCheckedChangeListener { _, isChecked ->
+            selectedAdaptiveBrightness = isChecked
+            prefs.edit().putBoolean(PREF_ADAPTIVE_BRIGHTNESS, isChecked).apply()
+
+            if (LEDService.isRunning && !serviceController.isServiceTransitioning) {
+                sendLiveUpdateToLedService()
+            }
+        }
+    }
+
@@ -2587,2 +2978,9 @@ class MainActivity : AppCompatActivity() {
-            val timestamp = SimpleDateFormat("yyyyMMdd_HHmmss", Locale.US).format(Date())
-            exportPresetsLauncher.launch("bifrost_presets_$timestamp.bifrost_preset")
+            showBackupCategoryDialog(
+                title = "BACKUP CATEGORIES",
+                subtitle = "Choose what to include in the backup",
+                confirmLabel = "BACKUP"
+            ) { options ->
+                pendingBackupExportOptions = options
+                val timestamp = SimpleDateFormat("yyyyMMdd_HHmmss", Locale.US).format(Date())
+                exportPresetsLauncher.launch("bifrost_backup_$timestamp.bifrost_backup")
+            }
@@ -2592 +2990,17 @@ class MainActivity : AppCompatActivity() {
-            importPresetsLauncher.launch(arrayOf("*/*"))
+            showBackupCategoryDialog(
+                title = "RESTORE CATEGORIES",
+                subtitle = "Choose what to restore from archive",
+                confirmLabel = "RESTORE"
+            ) { options ->
+                pendingBackupImportOptions = options
+                importPresetsLauncher.launch(arrayOf("*/*"))
+            }
+        }
+
+        exportThemeButton.setOnClickListener {
+            val timestamp = SimpleDateFormat("yyyyMMdd_HHmmss", Locale.US).format(Date())
+            exportThemeLauncher.launch("bifrost_theme_$timestamp.bifrost_theme")
+        }
+
+        importThemeButton.setOnClickListener {
+            importThemeLauncher.launch(arrayOf("*/*"))
@@ -2601 +3015 @@ class MainActivity : AppCompatActivity() {
-    private fun exportPresetBundle(uri: Uri) {
+    private fun exportPresetBundle(uri: Uri, options: BackupArchiveTransfer.CategoryOptions) {
@@ -2603,6 +3017 @@ class MainActivity : AppCompatActivity() {
-            PresetArchiveTransfer.exportToUri(
-                context = this,
-                uri = uri,
-                presets = presetController.getPresets(),
-                mappings = appProfileManager.getMappings()
-            )
+            BackupArchiveTransfer.exportToUri(context = this, uri = uri, options = options)
@@ -2610 +3019 @@ class MainActivity : AppCompatActivity() {
-            Toast.makeText(this, "Preset export failed", Toast.LENGTH_LONG).show()
+            Toast.makeText(this, "Backup export failed", Toast.LENGTH_LONG).show()
@@ -2617 +3026 @@ class MainActivity : AppCompatActivity() {
-                "Exported ${result.presetCount} presets (${result.iconCount} icons)",
+                "Backup saved (${result.preferenceCount} settings, ${result.iconCount} images)",
@@ -2626,2 +3035,2 @@ class MainActivity : AppCompatActivity() {
-            title = "EXPORT COMPLETED",
-            subtitle = "Exported ${result.presetCount} presets with ${result.warnings.size} warning(s)",
+            title = "BACKUP COMPLETED",
+            subtitle = "Saved backup with ${result.warnings.size} warning(s)",
@@ -2636,3 +3045,3 @@ class MainActivity : AppCompatActivity() {
-    private fun importPresetBundle(uri: Uri) {
-        val result = runCatching {
-            PresetArchiveTransfer.importFromUri(this, uri)
+    private fun importPresetBundle(uri: Uri, options: BackupArchiveTransfer.CategoryOptions) {
+        val backupResult = runCatching {
+            BackupArchiveTransfer.importFromUri(this, uri, options = options)
@@ -2652,0 +3062,49 @@ class MainActivity : AppCompatActivity() {
+        if (backupResult.errors.isEmpty()) {
+            val categorySummary = describeBackupCategories(backupResult.appliedOptions)
+            val warningText = if (backupResult.warnings.isEmpty()) {
+                "Categories: $categorySummary\n\nRestore completed successfully."
+            } else {
+                "Categories: $categorySummary\n\nWarnings:\n${backupResult.warnings.joinToString("\n")}"
+            }
+
+            BifrostAlertDialog().show(
+                activity = this,
+                title = "RESTORE COMPLETED",
+                subtitle = "Restored ${backupResult.preferenceCount} settings and ${backupResult.iconCount} images",
+                body = warningText,
+                positiveLabelResId = R.string.alert_action_ok,
+                negativeLabelResId = null,
+                cancelable = true,
+                onConfirm = {
+                    recreate()
+                }
+            )
+            return
+        }
+
+        // Fallback: allow importing legacy preset bundles through the same picker.
+        val result = runCatching {
+            PresetArchiveTransfer.importFromUri(this, uri)
+        }.getOrElse {
+            val mergedErrorText = buildString {
+                append(backupResult.errors.joinToString("\n"))
+                if (isNotEmpty()) append("\n\n")
+                append("Legacy preset import failed")
+                it.message?.let { message ->
+                    append(": ")
+                    append(message)
+                }
+            }
+            BifrostAlertDialog().show(
+                activity = this,
+                title = "IMPORT FAILED",
+                subtitle = "Selected file is not a valid backup archive",
+                body = mergedErrorText,
+                positiveLabelResId = R.string.alert_action_ok,
+                negativeLabelResId = null,
+                cancelable = true,
+                onConfirm = {}
+            )
+            return
+        }
+
@@ -2674,0 +3133,39 @@ class MainActivity : AppCompatActivity() {
+    private fun showBackupCategoryDialog(
+        title: String,
+        subtitle: String,
+        confirmLabel: String,
+        onConfirm: (BackupArchiveTransfer.CategoryOptions) -> Unit
+    ) {
+        val labels = arrayOf("Themes", "Profiles", "Images")
+        val checked = booleanArrayOf(true, true, true)
+
+        AlertDialog.Builder(this)
+            .setTitle(title)
+            .setMessage(subtitle)
+            .setMultiChoiceItems(labels, checked) { _, which, isChecked ->
+                checked[which] = isChecked
+            }
+            .setPositiveButton(confirmLabel) { _, _ ->
+                val options = BackupArchiveTransfer.CategoryOptions(
+                    themes = checked[0],
+                    profiles = checked[1],
+                    images = checked[2]
+                )
+                if (!options.hasAtLeastOneCategory()) {
+                    Toast.makeText(this, "Select at least one category", Toast.LENGTH_SHORT).show()
+                    return@setPositiveButton
+                }
+                onConfirm(options)
+            }
+            .setNegativeButton(R.string.action_cancel, null)
+            .show()
+    }
+
+    private fun describeBackupCategories(options: BackupArchiveTransfer.CategoryOptions): String {
+        val selected = mutableListOf<String>()
+        if (options.themes) selected += "Themes"
+        if (options.profiles) selected += "Profiles"
+        if (options.images) selected += "Images"
+        return if (selected.isEmpty()) "None" else selected.joinToString(" + ")
+    }
+
@@ -2709,0 +3207,112 @@ class MainActivity : AppCompatActivity() {
+    private fun exportThemeBundle(uri: Uri) {
+        val result = runCatching {
+            ThemeArchiveTransfer.exportToUri(
+                context = this,
+                uri = uri,
+                themeId = selectedUiTheme.id,
+                coloredLogoEnabled = isColoredLogoEnabled
+            )
+        }.getOrElse {
+            Toast.makeText(this, "Theme export failed", Toast.LENGTH_LONG).show()
+            return
+        }
+
+        if (result.warnings.isEmpty()) {
+            Toast.makeText(
+                this,
+                "Theme saved (${selectedUiTheme.label})",
+                Toast.LENGTH_LONG
+            ).show()
+            return
+        }
+
+        BifrostAlertDialog().show(
+            activity = this,
+            title = "THEME EXPORT COMPLETED",
+            subtitle = "Saved ${selectedUiTheme.label} with ${result.warnings.size} warning(s)",
+            body = result.warnings.joinToString("\n"),
+            positiveLabelResId = R.string.alert_action_ok,
+            negativeLabelResId = null,
+            cancelable = true,
+            onConfirm = {}
+        )
+    }
+
+    private fun importThemeBundle(uri: Uri) {
+        val result = runCatching {
+            ThemeArchiveTransfer.importFromUri(this, uri)
+        }.getOrElse {
+            BifrostAlertDialog().show(
+                activity = this,
+                title = "THEME IMPORT FAILED",
+                subtitle = "Selected file could not be imported",
+                body = it.message,
+                positiveLabelResId = R.string.alert_action_ok,
+                negativeLabelResId = null,
+                cancelable = true,
+                onConfirm = {}
+            )
+            return
+        }
+
+        val importedTheme = builtInThemes.firstOrNull { it.id == result.themeId }
+        val errors = result.errors.toMutableList()
+        if (importedTheme == null) {
+            errors += if (result.themeId.isNullOrBlank()) {
+                "Theme bundle does not contain a supported theme."
+            } else {
+                "Theme '${result.themeId}' is not available in this build."
+            }
+        }
+
+        if (errors.isNotEmpty()) {
+            BifrostAlertDialog().show(
+                activity = this,
+                title = "THEME IMPORT FAILED",
+                subtitle = "Selected file is not a valid supported theme bundle",
+                body = (errors + result.warnings).joinToString("\n"),
+                positiveLabelResId = R.string.alert_action_ok,
+                negativeLabelResId = null,
+                cancelable = true,
+                onConfirm = {}
+            )
+            return
+        }
+
+        applyImportedTheme(importedTheme!!, result.coloredLogoEnabled)
+
+        val body = if (result.warnings.isEmpty()) {
+            "Theme applied successfully."
+        } else {
+            "Warnings:\n${result.warnings.joinToString("\n")}"
+        }
+
+        BifrostAlertDialog().show(
+            activity = this,
+            title = "THEME IMPORT COMPLETED",
+            subtitle = "Applied ${importedTheme.label}",
+            body = body,
+            positiveLabelResId = R.string.alert_action_ok,
+            negativeLabelResId = null,
+            cancelable = true,
+            onConfirm = {}
+        )
+    }
+
+    private fun applyImportedTheme(theme: UiTheme, coloredLogoEnabled: Boolean) {
+        prefs.edit()
+            .putString(PREF_SELECTED_UI_THEME, theme.id)
+            .putBoolean(PREF_COLORED_LOGO_ENABLED, coloredLogoEnabled)
+            .apply()
+
+        isColoredLogoEnabled = coloredLogoEnabled
+        val themeIndex = builtInThemes.indexOfFirst { it.id == theme.id }.takeIf { it >= 0 } ?: 0
+        themeSpinner.setSelection(themeIndex, false)
+        applySelectedTheme(theme, persistSelection = false)
+        if (coloredLogoSwitch.isChecked != coloredLogoEnabled) {
+            coloredLogoSwitch.isChecked = coloredLogoEnabled
+        } else {
+            applyHeaderLogoPreference()
+        }
+    }
+
@@ -2798,2 +3407,2 @@ class MainActivity : AppCompatActivity() {
-            speedLabel?.visibility = if (needsSpeed || needsSmoothness) View.VISIBLE else View.GONE
-            speedSeekBar.visibility = if (needsSpeed || needsSmoothness) View.VISIBLE else View.GONE
+            speedLabel?.visibility = if (needsSpeed) View.VISIBLE else View.GONE
+            speedSeekBar.visibility = if (needsSpeed) View.VISIBLE else View.GONE
@@ -2801,2 +3410,2 @@ class MainActivity : AppCompatActivity() {
-            smoothnessLabel?.visibility = View.GONE
-            smoothnessSeekBar.visibility = View.GONE
+            smoothnessLabel?.visibility = if (needsSmoothness) View.VISIBLE else View.GONE
+            smoothnessSeekBar.visibility = if (needsSmoothness) View.VISIBLE else View.GONE
@@ -2972,0 +3582,4 @@ class MainActivity : AppCompatActivity() {
+            putExtra(
+                LEDService.EXTRA_ADAPTIVE_BRIGHTNESS,
+                selectedAdaptiveBrightness
+            )
@@ -3023,0 +3637,4 @@ class MainActivity : AppCompatActivity() {
+            putExtra(
+                LEDService.EXTRA_ADAPTIVE_BRIGHTNESS,
+                selectedAdaptiveBrightness
+            )
diff --git a/app/src/main/java/com/moonbench/bifrost/ThemeArchiveTransfer.kt b/app/src/main/java/com/moonbench/bifrost/ThemeArchiveTransfer.kt
new file mode 100644
index 0000000..4a21208
--- /dev/null
+++ b/app/src/main/java/com/moonbench/bifrost/ThemeArchiveTransfer.kt
@@ -0,0 +1,99 @@
+package com.moonbench.bifrost
+
+import android.content.Context
+import android.net.Uri
+import org.json.JSONObject
+
+object ThemeArchiveTransfer {
+
+    private const val THEME_SCHEMA = "bifrost_theme_bundle"
+    private const val THEME_VERSION = 1
+
+    data class ExportResult(
+        val themeId: String,
+        val warnings: List<String>
+    )
+
+    data class ImportResult(
+        val themeId: String?,
+        val coloredLogoEnabled: Boolean,
+        val warnings: List<String>,
+        val errors: List<String>
+    )
+
+    fun exportToUri(
+        context: Context,
+        uri: Uri,
+        themeId: String,
+        coloredLogoEnabled: Boolean
+    ): ExportResult {
+        val payload = JSONObject().apply {
+            put("schema", THEME_SCHEMA)
+            put("version", THEME_VERSION)
+            put("themeId", themeId)
+            put("coloredLogoEnabled", coloredLogoEnabled)
+        }
+
+        context.contentResolver.openOutputStream(uri)?.use { stream ->
+            stream.writer(Charsets.UTF_8).use { writer ->
+                writer.write(payload.toString(2))
+            }
+        } ?: return ExportResult(
+            themeId = themeId,
+            warnings = listOf("Unable to write selected file.")
+        )
+
+        return ExportResult(
+            themeId = themeId,
+            warnings = emptyList()
+        )
+    }
+
+    fun importFromUri(context: Context, uri: Uri): ImportResult {
+        val warnings = mutableListOf<String>()
+        val errors = mutableListOf<String>()
+
+        val rawJson = context.contentResolver.openInputStream(uri)?.use { input ->
+            input.bufferedReader(Charsets.UTF_8).use { reader ->
+                reader.readText()
+            }
+        } ?: return ImportResult(
+            themeId = null,
+            coloredLogoEnabled = true,
+            warnings = emptyList(),
+            errors = listOf("Unable to read selected file.")
+        )
+
+        val payload = runCatching { JSONObject(rawJson) }.getOrElse {
+            return ImportResult(
+                themeId = null,
+                coloredLogoEnabled = true,
+                warnings = emptyList(),
+                errors = listOf("Theme file is invalid JSON")
+            )
+        }
+
+        if (payload.optString("schema") != THEME_SCHEMA) {
+            errors += "Unknown theme bundle schema."
+        }
+
+        val version = payload.optInt("version", -1)
+        if (version < 1) {
+            errors += "Unsupported theme bundle version: $version"
+        } else if (version > THEME_VERSION) {
+            warnings += "Theme bundle version $version is newer than supported version $THEME_VERSION. Attempting compatible import."
+        }
+
+        val themeId = payload.optString("themeId").takeIf { it.isNotBlank() }
+        if (themeId == null) {
+            errors += "Theme bundle does not specify a theme."
+        }
+
+        return ImportResult(
+            themeId = themeId,
+            coloredLogoEnabled = payload.optBoolean("coloredLogoEnabled", true),
+            warnings = warnings,
+            errors = errors
+        )
+    }
+}
\ No newline at end of file
diff --git a/app/src/main/java/com/moonbench/bifrost/presets/PresetVisuals.kt b/app/src/main/java/com/moonbench/bifrost/presets/PresetVisuals.kt
index 950c30c..b2dcaf1 100644
--- a/app/src/main/java/com/moonbench/bifrost/presets/PresetVisuals.kt
+++ b/app/src/main/java/com/moonbench/bifrost/presets/PresetVisuals.kt
@@ -107,0 +108,20 @@ object PresetImageStorage {
+    fun listStoredIconFileNames(context: Context): List<String> {
+        val dir = resolveDirectory(context)
+        return dir.listFiles()
+            ?.asSequence()
+            ?.filter { it.isFile }
+            ?.map { it.name }
+            ?.sorted()
+            ?.toList()
+            ?: emptyList()
+    }
+
+    fun clearAllIcons(context: Context) {
+        val dir = resolveDirectory(context)
+        dir.listFiles()?.forEach { file ->
+            if (file.isFile) {
+                file.delete()
+            }
+        }
+    }
+
@@ -178,0 +199,10 @@ object PresetImageStorage {
+    fun writeIconWithExactName(context: Context, fileName: String, bytes: ByteArray): Boolean {
+        if (bytes.isEmpty() || bytes.size > MAX_IMAGE_BYTES) return false
+
+        return runCatching {
+            val targetFile = resolveFile(context, fileName)
+            FileOutputStream(targetFile).use { it.write(bytes) }
+            true
+        }.getOrDefault(false)
+    }
+
diff --git a/app/src/main/java/com/moonbench/bifrost/services/LEDService.kt b/app/src/main/java/com/moonbench/bifrost/services/LEDService.kt
index 34bae34..0831392 100644
--- a/app/src/main/java/com/moonbench/bifrost/services/LEDService.kt
+++ b/app/src/main/java/com/moonbench/bifrost/services/LEDService.kt
@@ -15,0 +16,2 @@ import android.content.pm.PackageManager
+import android.database.ContentObserver
+import android.provider.Settings
@@ -76,0 +79,4 @@ class LEDService : Service() {
+        const val EXTRA_ADAPTIVE_BRIGHTNESS = "adaptiveBrightness"
+
+        /** Minimum LED scale applied when screen brightness is at its lowest (0–255 → 0.25). */
+        private const val ADAPTIVE_BRIGHTNESS_MIN_SCALE = 0.25f
@@ -119,0 +126 @@ class LEDService : Service() {
+    private var currentAdaptiveBrightness: Boolean = false
@@ -129,0 +137 @@ class LEDService : Service() {
+    private var pendingFinalizeStopRunnable: Runnable? = null
@@ -131,0 +140,40 @@ class LEDService : Service() {
+    /**
+     * Maps the current system screen brightness (0–255) to an LED brightness multiplier.
+     * Brightness 0 → ADAPTIVE_BRIGHTNESS_MIN_SCALE, brightness 255 → 1.0.
+     */
+    private val screenBrightnessObserver = object : ContentObserver(Handler(Looper.getMainLooper())) {
+        override fun onChange(selfChange: Boolean) {
+            if (!currentAdaptiveBrightness) return
+            applyAdaptiveBrightnessToAnimation()
+        }
+    }
+
+    private fun screenBrightnessScale(): Float {
+        val raw = runCatching {
+            Settings.System.getInt(contentResolver, Settings.System.SCREEN_BRIGHTNESS)
+        }.getOrDefault(255)
+        val normalised = raw.coerceIn(0, 255) / 255f
+        return ADAPTIVE_BRIGHTNESS_MIN_SCALE + normalised * (1f - ADAPTIVE_BRIGHTNESS_MIN_SCALE)
+    }
+
+    private fun effectiveBrightness(): Int {
+        if (!currentAdaptiveBrightness) return currentBrightness
+        return (currentBrightness * screenBrightnessScale()).toInt().coerceIn(0, 255)
+    }
+
+    private fun applyAdaptiveBrightnessToAnimation() {
+        currentAnimation?.setTargetBrightness(effectiveBrightness())
+    }
+
+    private fun mountScreenBrightnessObserver() {
+        contentResolver.registerContentObserver(
+            Settings.System.getUriFor(Settings.System.SCREEN_BRIGHTNESS),
+            false,
+            screenBrightnessObserver
+        )
+    }
+
+    private fun unmountScreenBrightnessObserver() {
+        runCatching { contentResolver.unregisterContentObserver(screenBrightnessObserver) }
+    }
+
@@ -175,0 +224 @@ class LEDService : Service() {
+        mountScreenBrightnessObserver()
@@ -207,0 +257,4 @@ class LEDService : Service() {
+        // A new start intent can arrive while a delayed shutdown is still pending.
+        // Cancel pending teardown so we don't stop immediately after restarting.
+        reviveIfStopping()
+
@@ -216,0 +270,4 @@ class LEDService : Service() {
+        currentAdaptiveBrightness = intent.getBooleanExtra(
+            EXTRA_ADAPTIVE_BRIGHTNESS,
+            currentAdaptiveBrightness
+        )
@@ -286,0 +344 @@ class LEDService : Service() {
+
@@ -326 +384,9 @@ class LEDService : Service() {
-            animation?.setTargetBrightness(currentBrightness)
+            animation?.setTargetBrightness(effectiveBrightness())
+        }
+
+        if (intent.hasExtra(EXTRA_ADAPTIVE_BRIGHTNESS)) {
+            val newAdaptive = intent.getBooleanExtra(EXTRA_ADAPTIVE_BRIGHTNESS, currentAdaptiveBrightness)
+            if (newAdaptive != currentAdaptiveBrightness) {
+                currentAdaptiveBrightness = newAdaptive
+                animation?.setTargetBrightness(effectiveBrightness())
+            }
@@ -593,0 +660,3 @@ class LEDService : Service() {
+        // Apply adaptive brightness scaling on top of the user-configured brightness level.
+        val resolvedBrightness = effectiveBrightness()
+
@@ -606 +675 @@ class LEDService : Service() {
-                                    startAnimation(animationType, color, rightColor, brightness, speed, smoothness, sensitivity, profile, currentSaturationBoost)
+                                    startAnimation(animationType, color, rightColor, resolvedBrightness, speed, smoothness, sensitivity, profile, currentSaturationBoost)
@@ -632 +701 @@ class LEDService : Service() {
-                    startAnimation(animationType, color, rightColor, brightness, speed, smoothness, sensitivity, profile, currentSaturationBoost)
+                    startAnimation(animationType, color, rightColor, resolvedBrightness, speed, smoothness, sensitivity, profile, currentSaturationBoost)
@@ -786,0 +856 @@ class LEDService : Service() {
+        unmountScreenBrightnessObserver()
@@ -796,0 +867,8 @@ class LEDService : Service() {
+        pendingFinalizeStopRunnable?.let(handler::removeCallbacks)
+        pendingFinalizeStopRunnable = null
+    }
+
+    private fun reviveIfStopping() {
+        if (!isStopping.get()) return
+        clearPendingCallbacks()
+        isStopping.set(false)
@@ -823 +901 @@ class LEDService : Service() {
-                    handler.postDelayed({
+                    pendingFinalizeStopRunnable = Runnable {
@@ -827 +905,3 @@ class LEDService : Service() {
-                    }, LED_OFF_SETTLE_DELAY_MS)
+                        pendingFinalizeStopRunnable = null
+                    }
+                    handler.postDelayed(pendingFinalizeStopRunnable!!, LED_OFF_SETTLE_DELAY_MS)
diff --git a/app/src/main/java/com/moonbench/bifrost/services/ServiceController.kt b/app/src/main/java/com/moonbench/bifrost/services/ServiceController.kt
index 5a0e374..ac4f0c1 100644
--- a/app/src/main/java/com/moonbench/bifrost/services/ServiceController.kt
+++ b/app/src/main/java/com/moonbench/bifrost/services/ServiceController.kt
@@ -19,0 +20 @@ class ServiceController(
+    private var pendingTransitionClear: Runnable? = null
@@ -26,0 +28,2 @@ class ServiceController(
+        pendingTransitionClear?.let { handler.removeCallbacks(it) }
+        pendingTransitionClear = null
@@ -45,3 +48,9 @@ class ServiceController(
-        handler.postDelayed({
-            isServiceTransitioning = false
-        }, 200)
+        val token = operationToken
+        pendingTransitionClear?.let { handler.removeCallbacks(it) }
+        pendingTransitionClear = Runnable {
+            if (token == operationToken) {
+                isServiceTransitioning = false
+            }
+            pendingTransitionClear = null
+        }
+        handler.postDelayed(pendingTransitionClear!!, 200)
@@ -51 +60 @@ class ServiceController(
-        if (isOperationInProgress) return
+        if (isOperationInProgress) cancelPendingOperations()
@@ -68 +77 @@ class ServiceController(
-        if (isOperationInProgress) return
+        if (isOperationInProgress) cancelPendingOperations()
@@ -85 +94 @@ class ServiceController(
-        if (isOperationInProgress) return
+        if (isOperationInProgress) cancelPendingOperations()
diff --git a/app/src/main/res/layout/layout_settings_panel.xml b/app/src/main/res/layout/layout_settings_panel.xml
index 91ae468..5d2150d 100644
--- a/app/src/main/res/layout/layout_settings_panel.xml
+++ b/app/src/main/res/layout/layout_settings_panel.xml
@@ -128 +128 @@
-            android:text="EXPORT"
+            android:text="BACKUP"
@@ -143 +143 @@
-            android:text="IMPORT"
+            android:text="RESTORE"
@@ -152,0 +153,53 @@
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="12dp"
+        android:orientation="horizontal">
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/tabUiSettings"
+            android:layout_width="0dp"
+            android:layout_height="40dp"
+            android:layout_weight="1"
+            android:layout_marginEnd="4dp"
+            android:text="UI SETTINGS"
+            android:textColor="@color/bifrost_text"
+            android:textSize="10sp"
+            android:letterSpacing="0.05"
+            android:backgroundTint="@color/bifrost_surface"
+            app:cornerRadius="10dp"
+            app:strokeWidth="1dp"
+            app:strokeColor="@color/bifrost_accent" />
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/tabBehaviorSettings"
+            android:layout_width="0dp"
+            android:layout_height="40dp"
+            android:layout_weight="1"
+            android:layout_marginStart="2dp"
+            android:layout_marginEnd="2dp"
+            android:text="BEHAVIOUR"
+            android:textColor="@color/bifrost_text"
+            android:textSize="10sp"
+            android:letterSpacing="0.05"
+            android:backgroundTint="@color/bifrost_surface"
+            app:cornerRadius="10dp"
+            app:strokeWidth="1dp"
+            app:strokeColor="@color/bifrost_accent" />
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/tabThemesSettings"
+            android:layout_width="0dp"
+            android:layout_height="40dp"
+            android:layout_weight="1"
+            android:layout_marginStart="4dp"
+            android:text="THEMES"
+            android:textColor="@color/bifrost_text"
+            android:textSize="10sp"
+            android:letterSpacing="0.05"
+            android:backgroundTint="@color/bifrost_surface"
+            app:cornerRadius="10dp"
+            app:strokeWidth="1dp"
+            app:strokeColor="@color/bifrost_accent" />
+    </LinearLayout>
+
@@ -166,0 +220 @@
+                android:id="@+id/settingsSystemStatusCard"
@@ -300,0 +355,39 @@
+                    <LinearLayout
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:orientation="horizontal"
+                        android:gravity="center_vertical"
+                        android:layout_marginTop="12dp">
+
+                        <LinearLayout
+                            android:layout_width="0dp"
+                            android:layout_height="wrap_content"
+                            android:layout_weight="1"
+                            android:orientation="vertical">
+
+                            <TextView
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:text="ADAPTIVE LED BRIGHTNESS"
+                                android:textColor="@color/bifrost_text"
+                                android:textSize="12sp"
+                                android:letterSpacing="0.05"
+                                android:textStyle="bold" />
+
+                            <TextView
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:text="Scale LED brightness to match screen brightness"
+                                android:textColor="@color/bifrost_text_secondary"
+                                android:textSize="11sp"
+                                android:layout_marginTop="2dp" />
+                        </LinearLayout>
+
+                        <com.google.android.material.switchmaterial.SwitchMaterial
+                            android:id="@+id/adaptiveBrightnessSwitch"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            app:thumbTint="@color/switch_thumb_tint"
+                            app:trackTint="@color/switch_track_tint" />
+                    </LinearLayout>
+
@@ -1163,0 +1257,125 @@
+            <com.google.android.material.card.MaterialCardView
+                android:id="@+id/themesCard"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="@dimen/bifrost_spacing_md"
+                app:cardBackgroundColor="@color/bifrost_card"
+                app:cardCornerRadius="16dp"
+                app:cardElevation="0dp"
+                android:outlineAmbientShadowColor="@color/bifrost_glow_purple"
+                android:outlineSpotShadowColor="@color/bifrost_glow_purple"
+                android:visibility="gone">
+
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="vertical"
+                    android:padding="@dimen/bifrost_card_padding"
+                    android:background="@drawable/card_glow_bg">
+
+                    <TextView
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="THEMES"
+                        android:textColor="@color/bifrost_text"
+                        android:textSize="12sp"
+                        android:letterSpacing="0.08"
+                        android:textStyle="bold" />
+
+                    <TextView
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="2dp"
+                        android:layout_marginBottom="12dp"
+                        android:text="Switch between Classic and OLED Purple palettes"
+                        android:textColor="@color/bifrost_text_secondary"
+                        android:textSize="11sp" />
+
+                    <Spinner
+                        android:id="@+id/themeSpinner"
+                        android:layout_width="match_parent"
+                        android:layout_height="48dp"
+                        android:background="@drawable/bifrost_spinner_modern"
+                        android:paddingStart="12dp"
+                        android:paddingEnd="12dp"
+                        android:paddingTop="8dp"
+                        android:paddingBottom="8dp" />
+
+                    <LinearLayout
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="12dp"
+                        android:orientation="horizontal">
+
+                        <com.google.android.material.button.MaterialButton
+                            android:id="@+id/exportThemeButton"
+                            android:layout_width="0dp"
+                            android:layout_height="40dp"
+                            android:layout_weight="1"
+                            android:layout_marginEnd="4dp"
+                            android:text="EXPORT THEME"
+                            android:textSize="11sp"
+                            android:letterSpacing="0.05"
+                            android:textColor="@color/bifrost_text"
+                            android:backgroundTint="@color/bifrost_surface"
+                            app:cornerRadius="10dp"
+                            app:strokeWidth="1dp"
+                            app:strokeColor="@color/bifrost_accent" />
+
+                        <com.google.android.material.button.MaterialButton
+                            android:id="@+id/importThemeButton"
+                            android:layout_width="0dp"
+                            android:layout_height="40dp"
+                            android:layout_weight="1"
+                            android:layout_marginStart="4dp"
+                            android:text="IMPORT THEME"
+                            android:textSize="11sp"
+                            android:letterSpacing="0.05"
+                            android:textColor="@color/bifrost_text"
+                            android:backgroundTint="@color/bifrost_surface"
+                            app:cornerRadius="10dp"
+                            app:strokeWidth="1dp"
+                            app:strokeColor="@color/bifrost_accent" />
+                    </LinearLayout>
+
+                    <LinearLayout
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="12dp"
+                        android:orientation="horizontal"
+                        android:gravity="center_vertical">
+
+                        <LinearLayout
+                            android:layout_width="0dp"
+                            android:layout_height="wrap_content"
+                            android:layout_weight="1"
+                            android:orientation="vertical">
+
+                            <TextView
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:text="COLOURED LOGO"
+                                android:textColor="@color/bifrost_text"
+                                android:textSize="12sp"
+                                android:letterSpacing="0.05"
+                                android:textStyle="bold" />
+
+                            <TextView
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:layout_marginTop="2dp"
+                                android:text="Toggle animated color treatment for the Bifrost logo/title"
+                                android:textColor="@color/bifrost_text_secondary"
+                                android:textSize="11sp" />
+                        </LinearLayout>
+
+                        <com.google.android.material.switchmaterial.SwitchMaterial
+                            android:id="@+id/coloredLogoSwitch"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            app:thumbTint="@color/switch_thumb_tint"
+                            app:trackTint="@color/switch_track_tint" />
+                    </LinearLayout>
+                </LinearLayout>
+            </com.google.android.material.card.MaterialCardView>
+
```
